### PR TITLE
Add a season system with history and admin control

### DIFF
--- a/config/init_db.php
+++ b/config/init_db.php
@@ -40,7 +40,9 @@ try {
         date_partie TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
         gagnant_id INT,
         status ENUM('en_cours', 'terminee') DEFAULT 'en_cours',
-        FOREIGN KEY (gagnant_id) REFERENCES users(id)
+        season_id INT DEFAULT NULL,
+        FOREIGN KEY (gagnant_id) REFERENCES users(id),
+        INDEX idx_game_season (season_id)
     )");
     echo "✅ Table games créée\n";
     
@@ -88,11 +90,46 @@ try {
         new_elo INT NOT NULL,
         elo_change INT NOT NULL,
         rank INT NOT NULL COMMENT 'Rang réel du joueur dans la partie',
+        season_id INT DEFAULT NULL,
         timestamp TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
         FOREIGN KEY (game_id) REFERENCES games(id),
-        FOREIGN KEY (user_id) REFERENCES users(id)
+        FOREIGN KEY (user_id) REFERENCES users(id),
+        INDEX idx_elo_season (season_id)
     )");
     echo "✅ Table elo_history créée\n";
+
+    // Table seasons
+    echo "🏆 Création de la table seasons...\n";
+    $pdo->exec("CREATE TABLE IF NOT EXISTS seasons (
+        id INT AUTO_INCREMENT PRIMARY KEY,
+        name VARCHAR(100) NOT NULL,
+        start_date TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        end_date TIMESTAMP NULL,
+        is_current BOOLEAN DEFAULT FALSE,
+        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        INDEX idx_current_season (is_current),
+        INDEX idx_season_dates (start_date, end_date)
+    )");
+    echo "✅ Table seasons créée\n";
+    
+    // Table season_stats
+    echo "📊 Création de la table season_stats...\n";
+    $pdo->exec("CREATE TABLE IF NOT EXISTS season_stats (
+        id INT AUTO_INCREMENT PRIMARY KEY,
+        season_id INT NOT NULL,
+        user_id INT NOT NULL,
+        final_elo INT NOT NULL,
+        initial_elo INT DEFAULT 1000,
+        parties_jouees INT DEFAULT 0,
+        victoires INT DEFAULT 0,
+        final_rank INT DEFAULT NULL,
+        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        FOREIGN KEY (season_id) REFERENCES seasons(id) ON DELETE CASCADE,
+        FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+        UNIQUE KEY unique_season_user (season_id, user_id),
+        INDEX idx_season_rank (season_id, final_rank)
+    )");
+    echo "✅ Table season_stats créée\n";
 
     
     // Table admin (pour l'authentification)
@@ -122,6 +159,17 @@ try {
     // Vérifier le nombre d'utilisateurs ajoutés
     $count = $pdo->query("SELECT COUNT(*) FROM users")->fetchColumn();
     echo "✅ $count utilisateurs dans la base\n\n";
+    
+    // Créer la première saison
+    echo "🌟 Création de la première saison...\n";
+    $season_count = $pdo->query("SELECT COUNT(*) FROM seasons")->fetchColumn();
+    if ($season_count == 0) {
+        $pdo->exec("INSERT INTO seasons (name, is_current) VALUES ('Saison 1', TRUE)");
+        $season_id = $pdo->lastInsertId();
+        echo "✅ Saison 1 créée (ID: $season_id)\n";
+    } else {
+        echo "ℹ️  Saisons existantes trouvées ($season_count saisons)\n";
+    }
     
     echo "🎉 Base de données initialisée avec succès !\n";
     echo "🌐 Vous pouvez maintenant accéder à l'application\n";

--- a/config/migrate_seasons.php
+++ b/config/migrate_seasons.php
@@ -1,0 +1,115 @@
+<?php
+// Migration script for Season System
+echo "🏴‍☠️ Migration: Ajout du système de saisons...\n\n";
+
+// Configuration de la base de données
+$host = 'localhost';
+$username = 'skullking_user';
+$password = 'SkullKing_2025!';
+$db_name = 'skull_king_league';
+
+try {
+    echo "🔗 Connexion à MySQL...\n";
+    $pdo = new PDO("mysql:host=$host;dbname=$db_name", $username, $password);
+    $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+    echo "✅ Connexion réussie\n\n";
+    
+    // 1. Créer la table seasons
+    echo "🏆 Création de la table seasons...\n";
+    $pdo->exec("CREATE TABLE IF NOT EXISTS seasons (
+        id INT AUTO_INCREMENT PRIMARY KEY,
+        name VARCHAR(100) NOT NULL,
+        start_date TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        end_date TIMESTAMP NULL,
+        is_current BOOLEAN DEFAULT FALSE,
+        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        INDEX idx_current_season (is_current),
+        INDEX idx_season_dates (start_date, end_date)
+    )");
+    echo "✅ Table seasons créée\n";
+    
+    // 2. Ajouter les colonnes season_id et is_ranked à la table games
+    echo "🎮 Mise à jour de la table games...\n";
+    
+    // Vérifier si les colonnes existent déjà
+    $result = $pdo->query("SHOW COLUMNS FROM games LIKE 'season_id'");
+    if ($result->rowCount() == 0) {
+        $pdo->exec("ALTER TABLE games ADD COLUMN season_id INT DEFAULT NULL");
+        $pdo->exec("ALTER TABLE games ADD INDEX idx_game_season (season_id)");
+        echo "✅ Colonne season_id ajoutée à games\n";
+    } else {
+        echo "ℹ️  Colonne season_id existe déjà\n";
+    }
+    
+    $result = $pdo->query("SHOW COLUMNS FROM games LIKE 'is_ranked'");
+    if ($result->rowCount() == 0) {
+        $pdo->exec("ALTER TABLE games ADD COLUMN is_ranked BOOLEAN DEFAULT TRUE");
+        $pdo->exec("ALTER TABLE games ADD INDEX idx_game_ranked (is_ranked)");
+        echo "✅ Colonne is_ranked ajoutée à games\n";
+    } else {
+        echo "ℹ️  Colonne is_ranked existe déjà\n";
+    }
+    
+    // 3. Créer la première saison si aucune saison n'existe
+    echo "🌟 Vérification des saisons existantes...\n";
+    $count = $pdo->query("SELECT COUNT(*) FROM seasons")->fetchColumn();
+    
+    if ($count == 0) {
+        // Créer la saison 1
+        $pdo->exec("INSERT INTO seasons (name, is_current) VALUES ('Saison 1', TRUE)");
+        $season_id = $pdo->lastInsertId();
+        echo "✅ Saison 1 créée (ID: $season_id)\n";
+        
+        // Associer toutes les parties existantes à la saison 1
+        $pdo->exec("UPDATE games SET season_id = $season_id WHERE season_id IS NULL");
+        $updated_games = $pdo->query("SELECT COUNT(*) FROM games WHERE season_id = $season_id")->fetchColumn();
+        echo "✅ $updated_games parties associées à la Saison 1\n";
+    } else {
+        echo "ℹ️  Saisons existantes trouvées ($count saisons)\n";
+    }
+    
+    // 4. Ajouter season_id à elo_history si elle n'existe pas
+    echo "📈 Mise à jour de la table elo_history...\n";
+    $result = $pdo->query("SHOW COLUMNS FROM elo_history LIKE 'season_id'");
+    if ($result->rowCount() == 0) {
+        $pdo->exec("ALTER TABLE elo_history ADD COLUMN season_id INT DEFAULT NULL");
+        $pdo->exec("ALTER TABLE elo_history ADD INDEX idx_elo_season (season_id)");
+        echo "✅ Colonne season_id ajoutée à elo_history\n";
+        
+        // Associer l'historique ELO existant à la saison courante
+        $current_season = $pdo->query("SELECT id FROM seasons WHERE is_current = TRUE LIMIT 1")->fetchColumn();
+        if ($current_season) {
+            $pdo->exec("UPDATE elo_history SET season_id = $current_season WHERE season_id IS NULL");
+            echo "✅ Historique ELO associé à la saison courante\n";
+        }
+    } else {
+        echo "ℹ️  Colonne season_id existe déjà dans elo_history\n";
+    }
+    
+    // 5. Créer la table season_stats pour les statistiques par saison
+    echo "📊 Création de la table season_stats...\n";
+    $pdo->exec("CREATE TABLE IF NOT EXISTS season_stats (
+        id INT AUTO_INCREMENT PRIMARY KEY,
+        season_id INT NOT NULL,
+        user_id INT NOT NULL,
+        final_elo INT NOT NULL,
+        initial_elo INT DEFAULT 1000,
+        parties_jouees INT DEFAULT 0,
+        victoires INT DEFAULT 0,
+        final_rank INT DEFAULT NULL,
+        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+        FOREIGN KEY (season_id) REFERENCES seasons(id) ON DELETE CASCADE,
+        FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE,
+        UNIQUE KEY unique_season_user (season_id, user_id),
+        INDEX idx_season_rank (season_id, final_rank)
+    )");
+    echo "✅ Table season_stats créée\n";
+    
+    echo "\n🎉 Migration terminée avec succès !\n";
+    echo "🌐 Le système de saisons est maintenant prêt\n\n";
+    
+} catch(PDOException $e) {
+    echo "❌ Erreur: " . $e->getMessage() . "\n\n";
+    echo "💡 Vérifiez que la base de données est accessible et que l'utilisateur a les permissions nécessaires.\n";
+}
+?>

--- a/config/migrate_seasons.php
+++ b/config/migrate_seasons.php
@@ -28,10 +28,10 @@ try {
     )");
     echo "✅ Table seasons créée\n";
     
-    // 2. Ajouter les colonnes season_id et is_ranked à la table games
+    // 2. Ajouter la colonne season_id à la table games
     echo "🎮 Mise à jour de la table games...\n";
     
-    // Vérifier si les colonnes existent déjà
+    // Vérifier si la colonne existe déjà
     $result = $pdo->query("SHOW COLUMNS FROM games LIKE 'season_id'");
     if ($result->rowCount() == 0) {
         $pdo->exec("ALTER TABLE games ADD COLUMN season_id INT DEFAULT NULL");
@@ -39,15 +39,6 @@ try {
         echo "✅ Colonne season_id ajoutée à games\n";
     } else {
         echo "ℹ️  Colonne season_id existe déjà\n";
-    }
-    
-    $result = $pdo->query("SHOW COLUMNS FROM games LIKE 'is_ranked'");
-    if ($result->rowCount() == 0) {
-        $pdo->exec("ALTER TABLE games ADD COLUMN is_ranked BOOLEAN DEFAULT TRUE");
-        $pdo->exec("ALTER TABLE games ADD INDEX idx_game_ranked (is_ranked)");
-        echo "✅ Colonne is_ranked ajoutée à games\n";
-    } else {
-        echo "ℹ️  Colonne is_ranked existe déjà\n";
     }
     
     // 3. Créer la première saison si aucune saison n'existe

--- a/src/controllers/AdminController.php
+++ b/src/controllers/AdminController.php
@@ -59,7 +59,14 @@ switch($action) {
             (SELECT COUNT(*) FROM users) as total_users,
             (SELECT COUNT(*) FROM games WHERE status = 'terminee') as total_games,
             (SELECT COUNT(*) FROM games WHERE status = 'en_cours') as games_in_progress,
-            (SELECT COUNT(*) FROM seasons) as total_seasons
+            (SELECT COUNT(*) FROM seasons) as total_seasons,
+            (SELECT COUNT(DISTINCT g.user1_id) + COUNT(DISTINCT g.user2_id) 
+             FROM games g 
+             WHERE g.status = 'terminee' 
+             AND g.season_id = (SELECT id FROM seasons WHERE is_current = 1 LIMIT 1)) as active_players_current_season,
+            (SELECT COUNT(*) FROM games g 
+             WHERE g.status = 'terminee' 
+             AND g.season_id = (SELECT id FROM seasons WHERE is_current = 1 LIMIT 1)) as games_current_season
         ";
         $stats = $db->query($stats_query)->fetch(PDO::FETCH_ASSOC);
         

--- a/src/controllers/AdminController.php
+++ b/src/controllers/AdminController.php
@@ -2,11 +2,13 @@
 require_once '../config/database.php';
 require_once '../src/models/User.php';
 require_once '../src/models/Game.php';
+require_once '../src/models/Season.php';
 
 $database = new Database();
 $db = $database->getConnection();
 $user = new User($db);
 $game = new Game($db);
+$season = new Season($db);
 
 $action = $_GET['action'] ?? 'login';
 
@@ -56,9 +58,13 @@ switch($action) {
         $stats_query = "SELECT 
             (SELECT COUNT(*) FROM users) as total_users,
             (SELECT COUNT(*) FROM games WHERE status = 'terminee') as total_games,
-            (SELECT COUNT(*) FROM games WHERE status = 'en_cours') as games_in_progress
+            (SELECT COUNT(*) FROM games WHERE status = 'en_cours') as games_in_progress,
+            (SELECT COUNT(*) FROM seasons) as total_seasons
         ";
         $stats = $db->query($stats_query)->fetch(PDO::FETCH_ASSOC);
+        
+        // Get current season info
+        $current_season = $season->getCurrentSeason();
         
         include '../src/views/admin_dashboard.php';
         break;
@@ -139,6 +145,62 @@ switch($action) {
         
         header("Location: index.php?page=admin&action=games&error=delete_failed");
         exit;
+
+    case 'seasons':
+        if (!isAdminLoggedIn()) {
+            header("Location: index.php?page=admin&action=login");
+            exit;
+        }
+        
+        $all_seasons = $season->getAllSeasons();
+        $current_season = $season->getCurrentSeason();
+        include '../src/views/admin_seasons.php';
+        break;
+
+    case 'start_new_season':
+        if (!isAdminLoggedIn()) {
+            header("Location: index.php?page=admin&action=login");
+            exit;
+        }
+        
+        if ($_POST && isset($_POST['season_name'])) {
+            $season_name = trim($_POST['season_name']);
+            if (!empty($season_name)) {
+                try {
+                    $new_season_id = $season->startNewSeason($season_name);
+                    header("Location: index.php?page=admin&action=seasons&success=season_started&id=$new_season_id");
+                    exit;
+                } catch (Exception $e) {
+                    $error = "Erreur lors de la création de la saison: " . $e->getMessage();
+                }
+            } else {
+                $error = "Le nom de la saison ne peut pas être vide";
+            }
+        }
+        
+        $current_season = $season->getCurrentSeason();
+        include '../src/views/admin_start_season.php';
+        break;
+
+    case 'season_details':
+        if (!isAdminLoggedIn()) {
+            header("Location: index.php?page=admin&action=login");
+            exit;
+        }
+        
+        $season_id = $_GET['id'] ?? null;
+        if (!$season_id) {
+            header("Location: index.php?page=admin&action=seasons");
+            exit;
+        }
+        
+        $season_info = $season->getById($season_id);
+        $season_stats = $season->getSeasonStats($season_id);
+        $season_games = $season->getSeasonGames($season_id, true, 20);
+        $season_summary = $season->getSeasonSummary($season_id);
+        
+        include '../src/views/admin_season_details.php';
+        break;
 
     default:
         if (isAdminLoggedIn()) {

--- a/src/controllers/GameController.php
+++ b/src/controllers/GameController.php
@@ -15,11 +15,10 @@ switch($action) {
     case 'create':
         if ($_POST && isset($_POST['players']) && is_array($_POST['players'])) {
             $player_ids = $_POST['players'];
-            $is_ranked = isset($_POST['is_ranked']) ? (bool)$_POST['is_ranked'] : true; // Default to ranked
             
             if (count($player_ids) >= 1 && count($player_ids) <= 6) {
                 // Les joueurs sont déjà dans l'ordre souhaité grâce à l'interface
-                $game_id = $game->create($player_ids, $is_ranked);
+                $game_id = $game->create($player_ids);
                 if ($game_id) {
                     header("Location: index.php?page=game&action=play&id=" . $game_id);
                     exit;
@@ -107,9 +106,8 @@ switch($action) {
                     // Terminer la partie
                     $game->finishGame($game_id, $winner_id);
                     
-                    // Récupérer les infos de la partie pour savoir si c'est classé et la saison
+                    // Récupérer les infos de la partie pour la saison
                     $game_data = $game->getById($game_id);
-                    $is_ranked = $game_data['is_ranked'];
                     $season_id = $game_data['season_id'];
                     
                     // Mettre à jour les statistiques des joueurs
@@ -119,10 +117,8 @@ switch($action) {
                         $user->incrementStats($player['user_id'] == $winner_id, $season_id);
                     }
                     
-                    // Calculer les nouveaux ELO seulement si la partie est classée
-                    if ($is_ranked) {
-                        EloCalculator::updateElosAfterGame($db, $game_id, $winner_id);
-                    }
+                    // Calculer les nouveaux ELO pour toutes les parties
+                    EloCalculator::updateElosAfterGame($db, $game_id, $winner_id);
                     
                     header("Location: index.php?page=game&action=finish&id=" . $game_id);
                     exit;

--- a/src/controllers/GameController.php
+++ b/src/controllers/GameController.php
@@ -15,10 +15,11 @@ switch($action) {
     case 'create':
         if ($_POST && isset($_POST['players']) && is_array($_POST['players'])) {
             $player_ids = $_POST['players'];
+            $is_ranked = isset($_POST['is_ranked']) ? (bool)$_POST['is_ranked'] : true; // Default to ranked
             
             if (count($player_ids) >= 1 && count($player_ids) <= 6) {
                 // Les joueurs sont déjà dans l'ordre souhaité grâce à l'interface
-                $game_id = $game->create($player_ids);
+                $game_id = $game->create($player_ids, $is_ranked);
                 if ($game_id) {
                     header("Location: index.php?page=game&action=play&id=" . $game_id);
                     exit;
@@ -106,15 +107,22 @@ switch($action) {
                     // Terminer la partie
                     $game->finishGame($game_id, $winner_id);
                     
+                    // Récupérer les infos de la partie pour savoir si c'est classé et la saison
+                    $game_data = $game->getById($game_id);
+                    $is_ranked = $game_data['is_ranked'];
+                    $season_id = $game_data['season_id'];
+                    
                     // Mettre à jour les statistiques des joueurs
                     $players = $game->getPlayers($game_id);
                     while ($player = $players->fetch(PDO::FETCH_ASSOC)) {
                         $user->id = $player['user_id'];
-                        $user->incrementStats($player['user_id'] == $winner_id);
+                        $user->incrementStats($player['user_id'] == $winner_id, $season_id);
                     }
                     
-                    // Calculer les nouveaux ELO
-                    EloCalculator::updateElosAfterGame($db, $game_id, $winner_id);
+                    // Calculer les nouveaux ELO seulement si la partie est classée
+                    if ($is_ranked) {
+                        EloCalculator::updateElosAfterGame($db, $game_id, $winner_id);
+                    }
                     
                     header("Location: index.php?page=game&action=finish&id=" . $game_id);
                     exit;

--- a/src/models/Game.php
+++ b/src/models/Game.php
@@ -10,24 +10,23 @@ class Game {
     public $gagnant_id;
     public $status;
     public $season_id;
-    public $is_ranked;
 
     public function __construct($db) {
         $this->conn = $db;
     }
 
-    public function create($player_ids, $is_ranked = true) {
+    public function create($player_ids) {
         // Get current season
         require_once '../src/models/Season.php';
         $season_model = new Season($this->conn);
         $current_season = $season_model->getCurrentSeason();
         $season_id = $current_season ? $current_season['id'] : null;
         
-        // Créer la partie
-        $query = "INSERT INTO " . $this->table_name . " (status, season_id, is_ranked) VALUES ('en_cours', ?, ?)";
+        // Créer la partie - all games are ranked by default
+        $query = "INSERT INTO " . $this->table_name . " (status, season_id) VALUES ('en_cours', ?)";
         $stmt = $this->conn->prepare($query);
         
-        if($stmt->execute([$season_id, $is_ranked])) {
+        if($stmt->execute([$season_id])) {
             $game_id = $this->conn->lastInsertId();
             
             // Ajouter les joueurs à la partie avec l'ordre fourni
@@ -140,9 +139,8 @@ class Game {
         return $stmt->execute();
     }
 
-    public function getAll($limit = 20, $season_id = null, $ranked_only = false) {
+    public function getAll($limit = 20, $season_id = null) {
         $season_filter = $season_id ? "AND g.season_id = :season_id" : "";
-        $ranked_filter = $ranked_only ? "AND g.is_ranked = TRUE" : "";
         
         $query = "SELECT g.*, u.pseudo as gagnant_pseudo, s.name as season_name,
                          COUNT(gp.user_id) as nombre_joueurs
@@ -150,7 +148,7 @@ class Game {
                   LEFT JOIN users u ON g.gagnant_id = u.id
                   LEFT JOIN seasons s ON g.season_id = s.id
                   LEFT JOIN game_players gp ON g.id = gp.game_id
-                  WHERE g.status = 'terminee' $season_filter $ranked_filter
+                  WHERE g.status = 'terminee' $season_filter
                   GROUP BY g.id
                   ORDER BY g.date_partie DESC 
                   LIMIT :limit";

--- a/src/models/Game.php
+++ b/src/models/Game.php
@@ -9,17 +9,25 @@ class Game {
     public $date_partie;
     public $gagnant_id;
     public $status;
+    public $season_id;
+    public $is_ranked;
 
     public function __construct($db) {
         $this->conn = $db;
     }
 
-    public function create($player_ids) {
+    public function create($player_ids, $is_ranked = true) {
+        // Get current season
+        require_once '../src/models/Season.php';
+        $season_model = new Season($this->conn);
+        $current_season = $season_model->getCurrentSeason();
+        $season_id = $current_season ? $current_season['id'] : null;
+        
         // Créer la partie
-        $query = "INSERT INTO " . $this->table_name . " (status) VALUES ('en_cours')";
+        $query = "INSERT INTO " . $this->table_name . " (status, season_id, is_ranked) VALUES ('en_cours', ?, ?)";
         $stmt = $this->conn->prepare($query);
         
-        if($stmt->execute()) {
+        if($stmt->execute([$season_id, $is_ranked])) {
             $game_id = $this->conn->lastInsertId();
             
             // Ajouter les joueurs à la partie avec l'ordre fourni
@@ -42,9 +50,10 @@ class Game {
     }
 
     public function getById($id) {
-        $query = "SELECT g.*, u.pseudo as gagnant_pseudo 
+        $query = "SELECT g.*, u.pseudo as gagnant_pseudo, s.name as season_name
                   FROM " . $this->table_name . " g
                   LEFT JOIN users u ON g.gagnant_id = u.id
+                  LEFT JOIN seasons s ON g.season_id = s.id
                   WHERE g.id = ? LIMIT 0,1";
         $stmt = $this->conn->prepare($query);
         $stmt->bindParam(1, $id);
@@ -131,18 +140,26 @@ class Game {
         return $stmt->execute();
     }
 
-    public function getAll($limit = 20) {
-        $query = "SELECT g.*, u.pseudo as gagnant_pseudo,
+    public function getAll($limit = 20, $season_id = null, $ranked_only = false) {
+        $season_filter = $season_id ? "AND g.season_id = :season_id" : "";
+        $ranked_filter = $ranked_only ? "AND g.is_ranked = TRUE" : "";
+        
+        $query = "SELECT g.*, u.pseudo as gagnant_pseudo, s.name as season_name,
                          COUNT(gp.user_id) as nombre_joueurs
                   FROM " . $this->table_name . " g
                   LEFT JOIN users u ON g.gagnant_id = u.id
+                  LEFT JOIN seasons s ON g.season_id = s.id
                   LEFT JOIN game_players gp ON g.id = gp.game_id
-                  WHERE g.status = 'terminee'
+                  WHERE g.status = 'terminee' $season_filter $ranked_filter
                   GROUP BY g.id
                   ORDER BY g.date_partie DESC 
-                  LIMIT ?";
+                  LIMIT :limit";
         $stmt = $this->conn->prepare($query);
-        $stmt->bindParam(1, $limit, PDO::PARAM_INT);
+        
+        if ($season_id) {
+            $stmt->bindParam(':season_id', $season_id, PDO::PARAM_INT);
+        }
+        $stmt->bindParam(':limit', $limit, PDO::PARAM_INT);
         $stmt->execute();
         return $stmt;
     }

--- a/src/models/Season.php
+++ b/src/models/Season.php
@@ -197,6 +197,31 @@ class Season {
     }
 
     /**
+     * Get rankings for a specific season
+     * Returns live rankings for current season, saved stats for past seasons
+     */
+    public function getSeasonRankings($season_id) {
+        $current_season = $this->getCurrentSeason();
+        
+        // If this is the current season, return live rankings
+        if ($current_season && $season_id == $current_season['id']) {
+            return $this->getCurrentSeasonRankings();
+        }
+        
+        // For past seasons, return saved final stats
+        $query = "SELECT ss.user_id as id, u.pseudo, ss.final_elo as elo, 
+                         ss.parties_jouees, ss.victoires
+                  FROM season_stats ss
+                  JOIN users u ON ss.user_id = u.id
+                  WHERE ss.season_id = ?
+                  ORDER BY ss.final_rank ASC";
+        $stmt = $this->conn->prepare($query);
+        $stmt->bindParam(1, $season_id);
+        $stmt->execute();
+        return $stmt;
+    }
+
+    /**
      * Get season summary statistics
      */
     public function getSeasonSummary($season_id) {

--- a/src/models/Season.php
+++ b/src/models/Season.php
@@ -154,15 +154,13 @@ class Season {
     /**
      * Get games for a specific season
      */
-    public function getSeasonGames($season_id, $ranked_only = false, $limit = 50) {
-        $ranked_filter = $ranked_only ? "AND g.is_ranked = TRUE" : "";
-        
+    public function getSeasonGames($season_id, $limit = 50) {
         $query = "SELECT g.*, u.pseudo as gagnant_pseudo,
                          COUNT(gp.user_id) as nombre_joueurs
                   FROM games g
                   LEFT JOIN users u ON g.gagnant_id = u.id
                   LEFT JOIN game_players gp ON g.id = gp.game_id
-                  WHERE g.season_id = ? AND g.status = 'terminee' $ranked_filter
+                  WHERE g.season_id = ? AND g.status = 'terminee'
                   GROUP BY g.id
                   ORDER BY g.date_partie DESC 
                   LIMIT ?";
@@ -188,7 +186,7 @@ class Season {
                          SUM(CASE WHEN g.gagnant_id = u.id THEN 1 ELSE 0 END) as victoires
                   FROM users u
                   LEFT JOIN game_players gp ON u.id = gp.user_id
-                  LEFT JOIN games g ON gp.game_id = g.id AND g.season_id = ? AND g.status = 'terminee' AND g.is_ranked = TRUE
+                  LEFT JOIN games g ON gp.game_id = g.id AND g.season_id = ? AND g.status = 'terminee'
                   GROUP BY u.id, u.pseudo, u.elo
                   HAVING parties_jouees > 0
                   ORDER BY u.elo DESC";
@@ -211,7 +209,7 @@ class Season {
                   FROM games g
                   LEFT JOIN game_players gp ON g.id = gp.game_id
                   LEFT JOIN season_stats ss ON ss.season_id = g.season_id
-                  WHERE g.season_id = ? AND g.status = 'terminee' AND g.is_ranked = TRUE";
+                  WHERE g.season_id = ? AND g.status = 'terminee'";
         $stmt = $this->conn->prepare($query);
         $stmt->bindParam(1, $season_id);
         $stmt->execute();

--- a/src/models/Season.php
+++ b/src/models/Season.php
@@ -1,0 +1,221 @@
+<?php
+require_once '../config/database.php';
+
+class Season {
+    private $conn;
+    private $table_name = "seasons";
+
+    public $id;
+    public $name;
+    public $start_date;
+    public $end_date;
+    public $is_current;
+
+    public function __construct($db) {
+        $this->conn = $db;
+    }
+
+    /**
+     * Get current active season
+     */
+    public function getCurrentSeason() {
+        $query = "SELECT * FROM " . $this->table_name . " WHERE is_current = TRUE LIMIT 1";
+        $stmt = $this->conn->prepare($query);
+        $stmt->execute();
+        return $stmt->fetch(PDO::FETCH_ASSOC);
+    }
+
+    /**
+     * Get all seasons ordered by start date (newest first)
+     */
+    public function getAllSeasons() {
+        $query = "SELECT * FROM " . $this->table_name . " ORDER BY start_date DESC";
+        $stmt = $this->conn->prepare($query);
+        $stmt->execute();
+        return $stmt;
+    }
+
+    /**
+     * Get season by ID
+     */
+    public function getById($id) {
+        $query = "SELECT * FROM " . $this->table_name . " WHERE id = ? LIMIT 1";
+        $stmt = $this->conn->prepare($query);
+        $stmt->bindParam(1, $id);
+        $stmt->execute();
+        return $stmt->fetch(PDO::FETCH_ASSOC);
+    }
+
+    /**
+     * Start a new season - Admin only function
+     * This ends the current season and starts a new one, resetting all player ELOs to 1000
+     */
+    public function startNewSeason($season_name) {
+        try {
+            $this->conn->beginTransaction();
+
+            // 1. Get current season
+            $current_season = $this->getCurrentSeason();
+            
+            if ($current_season) {
+                // End current season
+                $this->endSeason($current_season['id']);
+            }
+
+            // 2. Create new season
+            $query = "INSERT INTO " . $this->table_name . " (name, is_current) VALUES (?, TRUE)";
+            $stmt = $this->conn->prepare($query);
+            $stmt->bindParam(1, $season_name);
+            $stmt->execute();
+            $new_season_id = $this->conn->lastInsertId();
+
+            // 3. Reset all user ELOs to 1000
+            $reset_query = "UPDATE users SET elo = 1000";
+            $this->conn->exec($reset_query);
+
+            $this->conn->commit();
+            return $new_season_id;
+
+        } catch (Exception $e) {
+            $this->conn->rollback();
+            throw $e;
+        }
+    }
+
+    /**
+     * End a season by setting end_date and is_current to false
+     * Also saves final statistics for the season
+     */
+    private function endSeason($season_id) {
+        // 1. Set end date and mark as not current
+        $query = "UPDATE " . $this->table_name . " 
+                  SET end_date = CURRENT_TIMESTAMP, is_current = FALSE 
+                  WHERE id = ?";
+        $stmt = $this->conn->prepare($query);
+        $stmt->bindParam(1, $season_id);
+        $stmt->execute();
+
+        // 2. Save final season statistics
+        $this->saveFinalStats($season_id);
+    }
+
+    /**
+     * Save final statistics for a completed season
+     */
+    private function saveFinalStats($season_id) {
+        // Get final standings for the season
+        $query = "SELECT u.id, u.pseudo, u.elo, u.parties_jouees, u.victoires
+                  FROM users u
+                  ORDER BY u.elo DESC";
+        $stmt = $this->conn->prepare($query);
+        $stmt->execute();
+        $users = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+        // Save final stats for each user
+        $insert_query = "INSERT INTO season_stats 
+                        (season_id, user_id, final_elo, parties_jouees, victoires, final_rank) 
+                        VALUES (?, ?, ?, ?, ?, ?)
+                        ON DUPLICATE KEY UPDATE 
+                        final_elo = VALUES(final_elo),
+                        parties_jouees = VALUES(parties_jouees),
+                        victoires = VALUES(victoires),
+                        final_rank = VALUES(final_rank)";
+        $insert_stmt = $this->conn->prepare($insert_query);
+
+        $rank = 1;
+        foreach ($users as $user) {
+            $insert_stmt->execute([
+                $season_id,
+                $user['id'],
+                $user['elo'],
+                $user['parties_jouees'],
+                $user['victoires'],
+                $rank
+            ]);
+            $rank++;
+        }
+    }
+
+    /**
+     * Get season statistics/final standings
+     */
+    public function getSeasonStats($season_id) {
+        $query = "SELECT ss.*, u.pseudo
+                  FROM season_stats ss
+                  JOIN users u ON ss.user_id = u.id
+                  WHERE ss.season_id = ?
+                  ORDER BY ss.final_rank ASC";
+        $stmt = $this->conn->prepare($query);
+        $stmt->bindParam(1, $season_id);
+        $stmt->execute();
+        return $stmt;
+    }
+
+    /**
+     * Get games for a specific season
+     */
+    public function getSeasonGames($season_id, $ranked_only = false, $limit = 50) {
+        $ranked_filter = $ranked_only ? "AND g.is_ranked = TRUE" : "";
+        
+        $query = "SELECT g.*, u.pseudo as gagnant_pseudo,
+                         COUNT(gp.user_id) as nombre_joueurs
+                  FROM games g
+                  LEFT JOIN users u ON g.gagnant_id = u.id
+                  LEFT JOIN game_players gp ON g.id = gp.game_id
+                  WHERE g.season_id = ? AND g.status = 'terminee' $ranked_filter
+                  GROUP BY g.id
+                  ORDER BY g.date_partie DESC 
+                  LIMIT ?";
+        $stmt = $this->conn->prepare($query);
+        $stmt->bindParam(1, $season_id);
+        $stmt->bindParam(2, $limit, PDO::PARAM_INT);
+        $stmt->execute();
+        return $stmt;
+    }
+
+    /**
+     * Get current season rankings (live standings)
+     */
+    public function getCurrentSeasonRankings() {
+        $current_season = $this->getCurrentSeason();
+        if (!$current_season) {
+            return false;
+        }
+
+        // Get users ranked by current ELO, but only include those who played in current season
+        $query = "SELECT DISTINCT u.id, u.pseudo, u.elo, 
+                         COUNT(DISTINCT g.id) as parties_jouees,
+                         SUM(CASE WHEN g.gagnant_id = u.id THEN 1 ELSE 0 END) as victoires
+                  FROM users u
+                  LEFT JOIN game_players gp ON u.id = gp.user_id
+                  LEFT JOIN games g ON gp.game_id = g.id AND g.season_id = ? AND g.status = 'terminee' AND g.is_ranked = TRUE
+                  GROUP BY u.id, u.pseudo, u.elo
+                  HAVING parties_jouees > 0
+                  ORDER BY u.elo DESC";
+        $stmt = $this->conn->prepare($query);
+        $stmt->bindParam(1, $current_season['id']);
+        $stmt->execute();
+        return $stmt;
+    }
+
+    /**
+     * Get season summary statistics
+     */
+    public function getSeasonSummary($season_id) {
+        $query = "SELECT 
+                    COUNT(DISTINCT g.id) as total_games,
+                    COUNT(DISTINCT gp.user_id) as total_players,
+                    AVG(ss.final_elo) as avg_final_elo,
+                    MAX(ss.final_elo) as max_elo,
+                    MIN(ss.final_elo) as min_elo
+                  FROM games g
+                  LEFT JOIN game_players gp ON g.id = gp.game_id
+                  LEFT JOIN season_stats ss ON ss.season_id = g.season_id
+                  WHERE g.season_id = ? AND g.status = 'terminee' AND g.is_ranked = TRUE";
+        $stmt = $this->conn->prepare($query);
+        $stmt->bindParam(1, $season_id);
+        $stmt->execute();
+        return $stmt->fetch(PDO::FETCH_ASSOC);
+    }
+}
+?>

--- a/src/models/User.php
+++ b/src/models/User.php
@@ -23,7 +23,7 @@ class User {
                              SUM(CASE WHEN g.gagnant_id = u.id THEN 1 ELSE 0 END) as victoires
                       FROM users u
                       LEFT JOIN game_players gp ON u.id = gp.user_id
-                      LEFT JOIN games g ON gp.game_id = g.id AND g.season_id = ? AND g.status = 'terminee' AND g.is_ranked = TRUE
+                      LEFT JOIN games g ON gp.game_id = g.id AND g.season_id = ? AND g.status = 'terminee'
                       GROUP BY u.id, u.pseudo, u.elo
                       HAVING parties_jouees > 0
                       ORDER BY u.elo DESC";

--- a/src/models/User.php
+++ b/src/models/User.php
@@ -15,11 +15,29 @@ class User {
         $this->conn = $db;
     }
 
-    public function getAll() {
-        $query = "SELECT * FROM " . $this->table_name . " ORDER BY elo DESC";
-        $stmt = $this->conn->prepare($query);
-        $stmt->execute();
-        return $stmt;
+    public function getAll($season_id = null) {
+        if ($season_id) {
+            // Get season-specific rankings
+            $query = "SELECT DISTINCT u.id, u.pseudo, u.elo, 
+                             COUNT(DISTINCT g.id) as parties_jouees,
+                             SUM(CASE WHEN g.gagnant_id = u.id THEN 1 ELSE 0 END) as victoires
+                      FROM users u
+                      LEFT JOIN game_players gp ON u.id = gp.user_id
+                      LEFT JOIN games g ON gp.game_id = g.id AND g.season_id = ? AND g.status = 'terminee' AND g.is_ranked = TRUE
+                      GROUP BY u.id, u.pseudo, u.elo
+                      HAVING parties_jouees > 0
+                      ORDER BY u.elo DESC";
+            $stmt = $this->conn->prepare($query);
+            $stmt->bindParam(1, $season_id);
+            $stmt->execute();
+            return $stmt;
+        } else {
+            // Get all-time rankings
+            $query = "SELECT * FROM " . $this->table_name . " ORDER BY elo DESC";
+            $stmt = $this->conn->prepare($query);
+            $stmt->execute();
+            return $stmt;
+        }
     }
 
     public function getById($id) {
@@ -81,15 +99,44 @@ class User {
         return $stmt->execute();
     }
 
-    public function incrementStats($won = false) {
+    public function incrementStats($won = false, $season_id = null) {
         $query = "UPDATE " . $this->table_name . " 
                   SET parties_jouees = parties_jouees + 1" . 
                   ($won ? ", victoires = victoires + 1" : "") . " 
                   WHERE id = ?";
         
         $stmt = $this->conn->prepare($query);
-        $stmt->bindParam(1, $this->id);
-        return $stmt->execute();
+        $result = $stmt->execute([$this->id]);
+        
+        // Also update season-specific stats if season_id is provided
+        if ($season_id && $result) {
+            $this->updateSeasonStats($season_id, $won);
+        }
+        
+        return $result;
+    }
+    
+    private function updateSeasonStats($season_id, $won) {
+        // Check if season stats record exists
+        $check_query = "SELECT id FROM season_stats WHERE season_id = ? AND user_id = ?";
+        $check_stmt = $this->conn->prepare($check_query);
+        $check_stmt->execute([$season_id, $this->id]);
+        
+        if ($check_stmt->fetch()) {
+            // Update existing record
+            $update_query = "UPDATE season_stats 
+                           SET parties_jouees = parties_jouees + 1" .
+                           ($won ? ", victoires = victoires + 1" : "") .
+                           " WHERE season_id = ? AND user_id = ?";
+            $update_stmt = $this->conn->prepare($update_query);
+            $update_stmt->execute([$season_id, $this->id]);
+        } else {
+            // Create new record
+            $insert_query = "INSERT INTO season_stats (season_id, user_id, parties_jouees, victoires, final_elo) 
+                           VALUES (?, ?, 1, " . ($won ? "1" : "0") . ", ?)";
+            $insert_stmt = $this->conn->prepare($insert_query);
+            $insert_stmt->execute([$season_id, $this->id, $this->elo]);
+        }
     }
 }
 ?>

--- a/src/views/admin_dashboard.php
+++ b/src/views/admin_dashboard.php
@@ -1,91 +1,169 @@
+<!-- Header -->
 <div class="d-flex justify-content-between align-items-center mb-4">
     <h2><i class="bi bi-speedometer2"></i> Tableau de bord administrateur</h2>
-    <div>
-        <span class="text-muted">Connecté en tant que : <strong><?php echo $_SESSION['admin_username']; ?></strong></span>
-        <a href="index.php?page=admin&action=logout" class="btn btn-outline-danger btn-sm ms-2">
+    <div class="d-flex align-items-center">
+        <span class="text-muted me-3">Connecté en tant que : <strong><?php echo $_SESSION['admin_username']; ?></strong></span>
+        <a href="index.php?page=admin&action=logout" class="btn btn-outline-danger btn-sm">
             <i class="bi bi-box-arrow-right"></i> Déconnexion
         </a>
     </div>
 </div>
 
-<!-- Statistiques -->
+<!-- Current Season Status -->
+<?php if ($current_season): ?>
 <div class="row mb-4">
-    <div class="col-md-4">
-        <div class="card text-center">
-            <div class="card-body">
-                <i class="bi bi-people-fill text-primary" style="font-size: 3rem;"></i>
-                <h3 class="mt-2"><?php echo $stats['total_users']; ?></h3>
-                <p class="text-muted">Utilisateurs</p>
+    <div class="col-12">
+        <div class="card border-primary">
+            <div class="card-header bg-primary text-white d-flex align-items-center">
+                <i class="bi bi-calendar-check me-2"></i>
+                <strong>Saison Actuelle</strong>
             </div>
-        </div>
-    </div>
-    <div class="col-md-4">
-        <div class="card text-center">
             <div class="card-body">
-                <i class="bi bi-controller text-success" style="font-size: 3rem;"></i>
-                <h3 class="mt-2"><?php echo $stats['total_games']; ?></h3>
-                <p class="text-muted">Parties terminées</p>
-            </div>
-        </div>
-    </div>
-    <div class="col-md-4">
-        <div class="card text-center">
-            <div class="card-body">
-                <i class="bi bi-calendar-event text-info" style="font-size: 3rem;"></i>
-                <h3 class="mt-2"><?php echo $stats['total_seasons']; ?></h3>
-                <p class="text-muted">Saisons</p>
+                <div class="row align-items-center">
+                    <div class="col-md-8">
+                        <h4 class="mb-1"><?php echo htmlspecialchars($current_season['name']); ?></h4>
+                        <p class="text-muted mb-0">
+                            <i class="bi bi-calendar3"></i> Démarrée le <?php echo date('d/m/Y', strtotime($current_season['start_date'])); ?>
+                            <?php 
+                            $days_running = floor((time() - strtotime($current_season['start_date'])) / (60 * 60 * 24));
+                            echo " · $days_running jours";
+                            ?>
+                        </p>
+                    </div>
+                    <div class="col-md-4 text-end">
+                        <a href="index.php?page=admin&action=seasons" class="btn btn-outline-primary btn-sm">
+                            <i class="bi bi-gear"></i> Gérer les saisons
+                        </a>
+                    </div>
+                </div>
             </div>
         </div>
     </div>
 </div>
-
-<!-- Current Season Info -->
-<?php if ($current_season): ?>
+<?php else: ?>
 <div class="row mb-4">
     <div class="col-12">
-        <div class="alert alert-info d-flex align-items-center">
-            <i class="bi bi-info-circle-fill me-2"></i>
-            <div>
-                <strong>Saison actuelle :</strong> <?php echo htmlspecialchars($current_season['name']); ?>
-                <span class="text-muted">
-                    (depuis le <?php echo date('d/m/Y', strtotime($current_season['start_date'])); ?>)
-                </span>
+        <div class="alert alert-warning d-flex align-items-center">
+            <i class="bi bi-exclamation-triangle-fill me-2"></i>
+            <div class="flex-grow-1">
+                <strong>Aucune saison active</strong> - Créez une nouvelle saison pour commencer la compétition
             </div>
+            <a href="index.php?page=admin&action=start_new_season" class="btn btn-warning btn-sm">
+                <i class="bi bi-plus-circle"></i> Créer une saison
+            </a>
         </div>
     </div>
 </div>
 <?php endif; ?>
 
-<!-- Actions rapides -->
-<div class="row">
-    <div class="col-md-4">
-        <div class="card h-100">
-            <div class="card-header">
-                <h5><i class="bi bi-calendar-event"></i> Gestion des Saisons</h5>
+<!-- Main Statistics -->
+<div class="row mb-4">
+    <div class="col-xl-3 col-md-6 mb-3">
+        <div class="card border-0 shadow-sm h-100">
+            <div class="card-body text-center">
+                <div class="d-flex justify-content-center align-items-center mb-3">
+                    <div class="bg-primary bg-opacity-10 rounded-circle p-3">
+                        <i class="bi bi-people-fill text-primary" style="font-size: 2rem;"></i>
+                    </div>
+                </div>
+                <h3 class="fw-bold"><?php echo $stats['total_users']; ?></h3>
+                <p class="text-muted mb-0">Utilisateurs inscrits</p>
+            </div>
+        </div>
+    </div>
+    <div class="col-xl-3 col-md-6 mb-3">
+        <div class="card border-0 shadow-sm h-100">
+            <div class="card-body text-center">
+                <div class="d-flex justify-content-center align-items-center mb-3">
+                    <div class="bg-success bg-opacity-10 rounded-circle p-3">
+                        <i class="bi bi-controller text-success" style="font-size: 2rem;"></i>
+                    </div>
+                </div>
+                <h3 class="fw-bold"><?php echo $stats['total_games']; ?></h3>
+                <p class="text-muted mb-0">Parties terminées</p>
+            </div>
+        </div>
+    </div>
+    <div class="col-xl-3 col-md-6 mb-3">
+        <div class="card border-0 shadow-sm h-100">
+            <div class="card-body text-center">
+                <div class="d-flex justify-content-center align-items-center mb-3">
+                    <div class="bg-warning bg-opacity-10 rounded-circle p-3">
+                        <i class="bi bi-hourglass-split text-warning" style="font-size: 2rem;"></i>
+                    </div>
+                </div>
+                <h3 class="fw-bold"><?php echo $stats['games_in_progress']; ?></h3>
+                <p class="text-muted mb-0">Parties en cours</p>
+            </div>
+        </div>
+    </div>
+    <div class="col-xl-3 col-md-6 mb-3">
+        <div class="card border-0 shadow-sm h-100">
+            <div class="card-body text-center">
+                <div class="d-flex justify-content-center align-items-center mb-3">
+                    <div class="bg-info bg-opacity-10 rounded-circle p-3">
+                        <i class="bi bi-calendar-event text-info" style="font-size: 2rem;"></i>
+                    </div>
+                </div>
+                <h3 class="fw-bold"><?php echo $stats['total_seasons']; ?></h3>
+                <p class="text-muted mb-0">Saisons créées</p>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- Management Actions -->
+<div class="row mb-4">
+    <div class="col-12">
+        <h4 class="mb-3"><i class="bi bi-gear-fill"></i> Gestion de la Ligue</h4>
+    </div>
+</div>
+
+<div class="row mb-4">
+    <div class="col-lg-4 col-md-6 mb-3">
+        <div class="card border-0 shadow-sm h-100">
+            <div class="card-header bg-light border-0">
+                <h5 class="mb-0 d-flex align-items-center">
+                    <div class="bg-primary bg-opacity-10 rounded me-2 p-2">
+                        <i class="bi bi-calendar-event text-primary"></i>
+                    </div>
+                    Saisons
+                </h5>
             </div>
             <div class="card-body">
-                <p>Gérez les saisons, démarrez de nouvelles compétitions et consultez l'historique.</p>
+                <p class="text-muted mb-3">Gérez les saisons, démarrez de nouvelles compétitions et consultez l'historique.</p>
                 <div class="d-grid gap-2">
-                    <a href="index.php?page=admin&action=seasons" class="btn btn-info">
-                        <i class="bi bi-list"></i> Voir les saisons
+                    <a href="index.php?page=admin&action=seasons" class="btn btn-outline-primary">
+                        <i class="bi bi-list"></i> Voir toutes les saisons
                     </a>
+                    <?php if ($current_season): ?>
                     <a href="index.php?page=admin&action=start_new_season" class="btn btn-warning">
                         <i class="bi bi-plus-circle"></i> Nouvelle saison
                     </a>
+                    <?php else: ?>
+                    <a href="index.php?page=admin&action=start_new_season" class="btn btn-primary">
+                        <i class="bi bi-plus-circle"></i> Créer première saison
+                    </a>
+                    <?php endif; ?>
                 </div>
             </div>
         </div>
     </div>
-    <div class="col-md-4">
-    <div class="col-md-4">
-        <div class="card h-100">
-            <div class="card-header">
-                <h5><i class="bi bi-people-fill"></i> Gestion des utilisateurs</h5>
+    
+    <div class="col-lg-4 col-md-6 mb-3">
+        <div class="card border-0 shadow-sm h-100">
+            <div class="card-header bg-light border-0">
+                <h5 class="mb-0 d-flex align-items-center">
+                    <div class="bg-success bg-opacity-10 rounded me-2 p-2">
+                        <i class="bi bi-people-fill text-success"></i>
+                    </div>
+                    Utilisateurs
+                </h5>
             </div>
             <div class="card-body">
-                <p>Ajoutez, modifiez ou supprimez des utilisateurs de la ligue.</p>
+                <p class="text-muted mb-3">Ajoutez, modifiez ou supprimez des utilisateurs de la ligue.</p>
                 <div class="d-grid gap-2">
-                    <a href="index.php?page=admin&action=users" class="btn btn-primary">
+                    <a href="index.php?page=admin&action=users" class="btn btn-outline-success">
                         <i class="bi bi-list"></i> Voir les utilisateurs
                     </a>
                     <a href="index.php?page=admin&action=add_user" class="btn btn-success">
@@ -95,18 +173,24 @@
             </div>
         </div>
     </div>
-    <div class="col-md-4">
-        <div class="card h-100">
-            <div class="card-header">
-                <h5><i class="bi bi-controller"></i> Gestion des parties</h5>
+    
+    <div class="col-lg-4 col-md-6 mb-3">
+        <div class="card border-0 shadow-sm h-100">
+            <div class="card-header bg-light border-0">
+                <h5 class="mb-0 d-flex align-items-center">
+                    <div class="bg-info bg-opacity-10 rounded me-2 p-2">
+                        <i class="bi bi-controller text-info"></i>
+                    </div>
+                    Parties
+                </h5>
             </div>
             <div class="card-body">
-                <p>Consultez et gérez l'historique des parties jouées.</p>
+                <p class="text-muted mb-3">Consultez et gérez l'historique des parties jouées.</p>
                 <div class="d-grid gap-2">
-                    <a href="index.php?page=admin&action=games" class="btn btn-info">
+                    <a href="index.php?page=admin&action=games" class="btn btn-outline-info">
                         <i class="bi bi-list"></i> Voir les parties
                     </a>
-                    <a href="index.php?page=history" class="btn btn-outline-info">
+                    <a href="index.php?page=history" class="btn btn-info">
                         <i class="bi bi-eye"></i> Vue utilisateur
                     </a>
                 </div>
@@ -115,53 +199,67 @@
     </div>
 </div>
 
-<!-- Additional Stats Row -->
-<div class="row mb-4">
-    <div class="col-md-6">
-        <div class="card text-center">
-            <div class="card-body">
-                <i class="bi bi-hourglass-split text-warning" style="font-size: 3rem;"></i>
-                <h3 class="mt-2"><?php echo $stats['games_in_progress']; ?></h3>
-                <p class="text-muted">Parties en cours</p>
-            </div>
-        </div>
-    </div>
-    <?php if ($current_season): ?>
-    <div class="col-md-6">
-        <div class="card text-center">
-            <div class="card-body">
-                <i class="bi bi-star-fill text-success" style="font-size: 3rem;"></i>
-                <h3 class="mt-2"><?php echo htmlspecialchars($current_season['name']); ?></h3>
-                <p class="text-muted">Saison actuelle</p>
-            </div>
-        </div>
-    </div>
-    <?php endif; ?>
-</div>
-
-<!-- Actions système -->
-<div class="row mt-4">
-    <div class="col-12">
-        <div class="card">
-            <div class="card-header">
-                <h5><i class="bi bi-gear-fill"></i> Actions système</h5>
+<!-- Quick Links & System Actions -->
+<div class="row">
+    <div class="col-lg-8 mb-3">
+        <div class="card border-0 shadow-sm">
+            <div class="card-header bg-light border-0">
+                <h5 class="mb-0"><i class="bi bi-lightning-fill"></i> Accès Rapide</h5>
             </div>
             <div class="card-body">
                 <div class="row">
-                    <div class="col-md-6">
-                        <h6>Base de données</h6>
-                        <p class="text-muted small">Assurez-vous que la base de données est correctement initialisée.</p>
-                        <a href="../config/init_db.php" target="_blank" class="btn btn-outline-warning btn-sm">
-                            <i class="bi bi-database"></i> Réinitialiser la DB
+                    <div class="col-md-6 mb-3">
+                        <h6 class="fw-bold">Classements</h6>
+                        <p class="text-muted small mb-2">Consultez les classements et statistiques des joueurs.</p>
+                        <a href="index.php?page=ranking" class="btn btn-outline-primary btn-sm">
+                            <i class="bi bi-trophy"></i> Voir le classement
+                        </a>
+                    </div>
+                    <div class="col-md-6 mb-3">
+                        <h6 class="fw-bold">Historique</h6>
+                        <p class="text-muted small mb-2">Parcourez l'historique complet des parties.</p>
+                        <a href="index.php?page=history" class="btn btn-outline-primary btn-sm">
+                            <i class="bi bi-clock-history"></i> Voir l'historique
                         </a>
                     </div>
                     <div class="col-md-6">
-                        <h6>Navigation</h6>
-                        <p class="text-muted small">Retourner à l'interface utilisateur.</p>
+                        <h6 class="fw-bold">Interface utilisateur</h6>
+                        <p class="text-muted small mb-2">Retourner à l'interface principale.</p>
                         <a href="index.php" class="btn btn-outline-primary btn-sm">
                             <i class="bi bi-house"></i> Accueil utilisateur
                         </a>
                     </div>
+                    <div class="col-md-6">
+                        <h6 class="fw-bold">Nouvelle partie</h6>
+                        <p class="text-muted small mb-2">Démarrer une nouvelle partie rapidement.</p>
+                        <a href="index.php?page=game&action=create" class="btn btn-outline-success btn-sm">
+                            <i class="bi bi-plus-circle"></i> Créer une partie
+                        </a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+    
+    <div class="col-lg-4 mb-3">
+        <div class="card border-0 shadow-sm">
+            <div class="card-header bg-light border-0">
+                <h5 class="mb-0"><i class="bi bi-gear-fill"></i> Système</h5>
+            </div>
+            <div class="card-body">
+                <div class="mb-3">
+                    <h6 class="fw-bold">Base de données</h6>
+                    <p class="text-muted small mb-2">Réinitialiser la structure de la base de données.</p>
+                    <a href="../config/init_db.php" target="_blank" class="btn btn-outline-warning btn-sm">
+                        <i class="bi bi-database"></i> Réinit. DB
+                    </a>
+                </div>
+                <div>
+                    <h6 class="fw-bold">Documentation</h6>
+                    <p class="text-muted small mb-2">Consultez la documentation technique.</p>
+                    <a href="../DEVELOPERS.md" target="_blank" class="btn btn-outline-info btn-sm">
+                        <i class="bi bi-book"></i> Guide dev
+                    </a>
                 </div>
             </div>
         </div>

--- a/src/views/admin_dashboard.php
+++ b/src/views/admin_dashboard.php
@@ -31,17 +31,53 @@
     <div class="col-md-4">
         <div class="card text-center">
             <div class="card-body">
-                <i class="bi bi-hourglass-split text-warning" style="font-size: 3rem;"></i>
-                <h3 class="mt-2"><?php echo $stats['games_in_progress']; ?></h3>
-                <p class="text-muted">Parties en cours</p>
+                <i class="bi bi-calendar-event text-info" style="font-size: 3rem;"></i>
+                <h3 class="mt-2"><?php echo $stats['total_seasons']; ?></h3>
+                <p class="text-muted">Saisons</p>
             </div>
         </div>
     </div>
 </div>
 
+<!-- Current Season Info -->
+<?php if ($current_season): ?>
+<div class="row mb-4">
+    <div class="col-12">
+        <div class="alert alert-info d-flex align-items-center">
+            <i class="bi bi-info-circle-fill me-2"></i>
+            <div>
+                <strong>Saison actuelle :</strong> <?php echo htmlspecialchars($current_season['name']); ?>
+                <span class="text-muted">
+                    (depuis le <?php echo date('d/m/Y', strtotime($current_season['start_date'])); ?>)
+                </span>
+            </div>
+        </div>
+    </div>
+</div>
+<?php endif; ?>
+
 <!-- Actions rapides -->
 <div class="row">
-    <div class="col-md-6">
+    <div class="col-md-4">
+        <div class="card h-100">
+            <div class="card-header">
+                <h5><i class="bi bi-calendar-event"></i> Gestion des Saisons</h5>
+            </div>
+            <div class="card-body">
+                <p>Gérez les saisons, démarrez de nouvelles compétitions et consultez l'historique.</p>
+                <div class="d-grid gap-2">
+                    <a href="index.php?page=admin&action=seasons" class="btn btn-info">
+                        <i class="bi bi-list"></i> Voir les saisons
+                    </a>
+                    <a href="index.php?page=admin&action=start_new_season" class="btn btn-warning">
+                        <i class="bi bi-plus-circle"></i> Nouvelle saison
+                    </a>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-4">
+    <div class="col-md-4">
         <div class="card h-100">
             <div class="card-header">
                 <h5><i class="bi bi-people-fill"></i> Gestion des utilisateurs</h5>
@@ -59,7 +95,7 @@
             </div>
         </div>
     </div>
-    <div class="col-md-6">
+    <div class="col-md-4">
         <div class="card h-100">
             <div class="card-header">
                 <h5><i class="bi bi-controller"></i> Gestion des parties</h5>
@@ -77,6 +113,30 @@
             </div>
         </div>
     </div>
+</div>
+
+<!-- Additional Stats Row -->
+<div class="row mb-4">
+    <div class="col-md-6">
+        <div class="card text-center">
+            <div class="card-body">
+                <i class="bi bi-hourglass-split text-warning" style="font-size: 3rem;"></i>
+                <h3 class="mt-2"><?php echo $stats['games_in_progress']; ?></h3>
+                <p class="text-muted">Parties en cours</p>
+            </div>
+        </div>
+    </div>
+    <?php if ($current_season): ?>
+    <div class="col-md-6">
+        <div class="card text-center">
+            <div class="card-body">
+                <i class="bi bi-star-fill text-success" style="font-size: 3rem;"></i>
+                <h3 class="mt-2"><?php echo htmlspecialchars($current_season['name']); ?></h3>
+                <p class="text-muted">Saison actuelle</p>
+            </div>
+        </div>
+    </div>
+    <?php endif; ?>
 </div>
 
 <!-- Actions système -->

--- a/src/views/admin_season_details.php
+++ b/src/views/admin_season_details.php
@@ -1,0 +1,215 @@
+<div class="d-flex justify-content-between align-items-center mb-4">
+    <h2>
+        <i class="bi bi-calendar-event"></i> 
+        <?php echo htmlspecialchars($season_info['name']); ?>
+    </h2>
+    <div>
+        <?php if ($season_info['is_current']): ?>
+            <span class="badge bg-success fs-6">
+                <i class="bi bi-star-fill"></i> Saison Actuelle
+            </span>
+        <?php else: ?>
+            <span class="badge bg-secondary fs-6">
+                <i class="bi bi-archive"></i> Saison Terminée
+            </span>
+        <?php endif; ?>
+        <a href="index.php?page=admin&action=seasons" class="btn btn-outline-secondary ms-2">
+            <i class="bi bi-arrow-left"></i> Retour
+        </a>
+    </div>
+</div>
+
+<!-- Season Info -->
+<div class="row mb-4">
+    <div class="col-md-12">
+        <div class="card">
+            <div class="card-header">
+                <h5><i class="bi bi-info-circle"></i> Informations de la Saison</h5>
+            </div>
+            <div class="card-body">
+                <div class="row">
+                    <div class="col-md-3">
+                        <strong>Date de début :</strong><br>
+                        <i class="bi bi-calendar3"></i> 
+                        <?php echo date('d/m/Y à H:i', strtotime($season_info['start_date'])); ?>
+                    </div>
+                    <div class="col-md-3">
+                        <strong>Date de fin :</strong><br>
+                        <?php if ($season_info['end_date']): ?>
+                            <i class="bi bi-calendar-x"></i> 
+                            <?php echo date('d/m/Y à H:i', strtotime($season_info['end_date'])); ?>
+                        <?php else: ?>
+                            <span class="text-muted">En cours...</span>
+                        <?php endif; ?>
+                    </div>
+                    <div class="col-md-3">
+                        <strong>Durée :</strong><br>
+                        <?php 
+                        $start = new DateTime($season_info['start_date']);
+                        $end = $season_info['end_date'] ? new DateTime($season_info['end_date']) : new DateTime();
+                        $diff = $start->diff($end);
+                        echo $diff->days . ' jours';
+                        ?>
+                    </div>
+                    <div class="col-md-3">
+                        <strong>Statut :</strong><br>
+                        <?php if ($season_info['is_current']): ?>
+                            <span class="badge bg-success">Active</span>
+                        <?php else: ?>
+                            <span class="badge bg-secondary">Terminée</span>
+                        <?php endif; ?>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<!-- Season Summary Stats -->
+<?php if ($season_summary && $season_summary['total_games'] > 0): ?>
+<div class="row mb-4">
+    <div class="col-md-12">
+        <div class="card">
+            <div class="card-header">
+                <h5><i class="bi bi-graph-up"></i> Statistiques de la Saison</h5>
+            </div>
+            <div class="card-body">
+                <div class="row text-center">
+                    <div class="col-md-2">
+                        <div class="border-end">
+                            <h3 class="text-primary"><?php echo $season_summary['total_games']; ?></h3>
+                            <p class="text-muted mb-0">Parties Jouées</p>
+                        </div>
+                    </div>
+                    <div class="col-md-2">
+                        <div class="border-end">
+                            <h3 class="text-success"><?php echo $season_summary['total_players']; ?></h3>
+                            <p class="text-muted mb-0">Joueurs Actifs</p>
+                        </div>
+                    </div>
+                    <div class="col-md-2">
+                        <div class="border-end">
+                            <h3 class="text-warning"><?php echo round($season_summary['avg_final_elo']); ?></h3>
+                            <p class="text-muted mb-0">ELO Moyen</p>
+                        </div>
+                    </div>
+                    <div class="col-md-3">
+                        <div class="border-end">
+                            <h3 class="text-danger"><?php echo $season_summary['max_elo']; ?></h3>
+                            <p class="text-muted mb-0">ELO Maximum</p>
+                        </div>
+                    </div>
+                    <div class="col-md-3">
+                        <h3 class="text-info"><?php echo $season_summary['min_elo']; ?></h3>
+                        <p class="text-muted mb-0">ELO Minimum</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+<?php endif; ?>
+
+<!-- Final Rankings -->
+<div class="row mb-4">
+    <div class="col-md-6">
+        <div class="card">
+            <div class="card-header">
+                <h5>
+                    <i class="bi bi-trophy"></i> 
+                    <?php echo $season_info['is_current'] ? 'Classement Actuel' : 'Classement Final'; ?>
+                </h5>
+            </div>
+            <div class="card-body">
+                <?php if ($season_stats && $season_stats->rowCount() > 0): ?>
+                <div class="table-responsive">
+                    <table class="table table-sm">
+                        <thead>
+                            <tr>
+                                <th>Rang</th>
+                                <th>Joueur</th>
+                                <th>ELO</th>
+                                <th>Parties</th>
+                                <th>Victoires</th>
+                                <th>%</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <?php while ($player = $season_stats->fetch(PDO::FETCH_ASSOC)): 
+                                $win_rate = $player['parties_jouees'] > 0 ? round(($player['victoires'] / $player['parties_jouees']) * 100) : 0;
+                            ?>
+                            <tr>
+                                <td>
+                                    <?php if ($player['final_rank'] == 1): ?>
+                                        <i class="bi bi-trophy-fill text-warning"></i>
+                                    <?php elseif ($player['final_rank'] == 2): ?>
+                                        <i class="bi bi-award-fill text-secondary"></i>
+                                    <?php elseif ($player['final_rank'] == 3): ?>
+                                        <i class="bi bi-award-fill text-warning"></i>
+                                    <?php else: ?>
+                                        <?php echo $player['final_rank']; ?>
+                                    <?php endif; ?>
+                                </td>
+                                <td><strong><?php echo htmlspecialchars($player['pseudo']); ?></strong></td>
+                                <td><span class="badge bg-info"><?php echo $player['final_elo']; ?></span></td>
+                                <td><?php echo $player['parties_jouees']; ?></td>
+                                <td><?php echo $player['victoires']; ?></td>
+                                <td><?php echo $win_rate; ?>%</td>
+                            </tr>
+                            <?php endwhile; ?>
+                        </tbody>
+                    </table>
+                </div>
+                <?php else: ?>
+                <div class="alert alert-info">
+                    <i class="bi bi-info-circle"></i>
+                    <?php echo $season_info['is_current'] ? 'Aucune partie jouée dans cette saison.' : 'Aucune statistique disponible pour cette saison.'; ?>
+                </div>
+                <?php endif; ?>
+            </div>
+        </div>
+    </div>
+    
+    <div class="col-md-6">
+        <div class="card">
+            <div class="card-header">
+                <h5><i class="bi bi-clock-history"></i> Parties Récentes</h5>
+            </div>
+            <div class="card-body">
+                <?php if ($season_games && $season_games->rowCount() > 0): ?>
+                <div class="table-responsive">
+                    <table class="table table-sm">
+                        <thead>
+                            <tr>
+                                <th>Date</th>
+                                <th>Gagnant</th>
+                                <th>Joueurs</th>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <?php while ($game = $season_games->fetch(PDO::FETCH_ASSOC)): ?>
+                            <tr>
+                                <td class="small">
+                                    <?php echo date('d/m H:i', strtotime($game['date_partie'])); ?>
+                                </td>
+                                <td>
+                                    <strong><?php echo htmlspecialchars($game['gagnant_pseudo']); ?></strong>
+                                </td>
+                                <td>
+                                    <span class="badge bg-primary"><?php echo $game['nombre_joueurs']; ?></span>
+                                </td>
+                            </tr>
+                            <?php endwhile; ?>
+                        </tbody>
+                    </table>
+                </div>
+                <?php else: ?>
+                <div class="alert alert-info">
+                    <i class="bi bi-info-circle"></i>
+                    Aucune partie jouée dans cette saison.
+                </div>
+                <?php endif; ?>
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/views/admin_seasons.php
+++ b/src/views/admin_seasons.php
@@ -1,0 +1,159 @@
+<div class="d-flex justify-content-between align-items-center mb-4">
+    <h2><i class="bi bi-calendar-event"></i> Gestion des Saisons</h2>
+    <a href="index.php?page=admin&action=start_new_season" class="btn btn-success">
+        <i class="bi bi-plus-circle"></i> Nouvelle Saison
+    </a>
+</div>
+
+<?php if (isset($_GET['success'])): ?>
+    <div class="alert alert-success alert-dismissible fade show" role="alert">
+        <?php if ($_GET['success'] == 'season_started'): ?>
+            <i class="bi bi-check-circle"></i> Nouvelle saison créée avec succès !
+        <?php endif; ?>
+        <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
+    </div>
+<?php endif; ?>
+
+<!-- Current Season Card -->
+<?php if ($current_season): ?>
+<div class="row mb-4">
+    <div class="col-12">
+        <div class="card border-success">
+            <div class="card-header bg-success text-white">
+                <h5 class="mb-0">
+                    <i class="bi bi-star-fill"></i> Saison Actuelle
+                </h5>
+            </div>
+            <div class="card-body">
+                <div class="row">
+                    <div class="col-md-8">
+                        <h4><?php echo htmlspecialchars($current_season['name']); ?></h4>
+                        <p class="text-muted">
+                            <i class="bi bi-calendar3"></i> 
+                            Commencée le <?php echo date('d/m/Y à H:i', strtotime($current_season['start_date'])); ?>
+                        </p>
+                    </div>
+                    <div class="col-md-4 text-end">
+                        <a href="index.php?page=admin&action=season_details&id=<?php echo $current_season['id']; ?>" 
+                           class="btn btn-outline-primary">
+                            <i class="bi bi-eye"></i> Voir détails
+                        </a>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+<?php endif; ?>
+
+<!-- All Seasons -->
+<div class="card">
+    <div class="card-header">
+        <h5><i class="bi bi-list"></i> Historique des Saisons</h5>
+    </div>
+    <div class="card-body">
+        <?php if ($all_seasons && $all_seasons->rowCount() > 0): ?>
+        <div class="table-responsive">
+            <table class="table table-striped table-hover">
+                <thead class="table-dark">
+                    <tr>
+                        <th>Nom</th>
+                        <th>Statut</th>
+                        <th>Date de début</th>
+                        <th>Date de fin</th>
+                        <th>Durée</th>
+                        <th>Actions</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <?php while ($season_row = $all_seasons->fetch(PDO::FETCH_ASSOC)): 
+                        $duration = '';
+                        if ($season_row['end_date']) {
+                            $start = new DateTime($season_row['start_date']);
+                            $end = new DateTime($season_row['end_date']);
+                            $diff = $start->diff($end);
+                            $duration = $diff->days . ' jours';
+                        } else {
+                            $start = new DateTime($season_row['start_date']);
+                            $now = new DateTime();
+                            $diff = $start->diff($now);
+                            $duration = $diff->days . ' jours (en cours)';
+                        }
+                    ?>
+                    <tr>
+                        <td>
+                            <strong><?php echo htmlspecialchars($season_row['name']); ?></strong>
+                            <?php if ($season_row['is_current']): ?>
+                                <span class="badge bg-success ms-2">Actuelle</span>
+                            <?php endif; ?>
+                        </td>
+                        <td>
+                            <?php if ($season_row['is_current']): ?>
+                                <span class="badge bg-success">
+                                    <i class="bi bi-play-fill"></i> En cours
+                                </span>
+                            <?php else: ?>
+                                <span class="badge bg-secondary">
+                                    <i class="bi bi-stop-fill"></i> Terminée
+                                </span>
+                            <?php endif; ?>
+                        </td>
+                        <td>
+                            <i class="bi bi-calendar3"></i>
+                            <?php echo date('d/m/Y H:i', strtotime($season_row['start_date'])); ?>
+                        </td>
+                        <td>
+                            <?php if ($season_row['end_date']): ?>
+                                <i class="bi bi-calendar-x"></i>
+                                <?php echo date('d/m/Y H:i', strtotime($season_row['end_date'])); ?>
+                            <?php else: ?>
+                                <span class="text-muted">-</span>
+                            <?php endif; ?>
+                        </td>
+                        <td><?php echo $duration; ?></td>
+                        <td>
+                            <a href="index.php?page=admin&action=season_details&id=<?php echo $season_row['id']; ?>" 
+                               class="btn btn-sm btn-outline-info">
+                                <i class="bi bi-eye"></i> Détails
+                            </a>
+                        </td>
+                    </tr>
+                    <?php endwhile; ?>
+                </tbody>
+            </table>
+        </div>
+        <?php else: ?>
+        <div class="alert alert-info text-center">
+            <i class="bi bi-info-circle"></i>
+            Aucune saison trouvée. Créez votre première saison !
+        </div>
+        <?php endif; ?>
+    </div>
+</div>
+
+<!-- Help Card -->
+<div class="row mt-4">
+    <div class="col-12">
+        <div class="card">
+            <div class="card-header">
+                <h5><i class="bi bi-question-circle"></i> À propos des Saisons</h5>
+            </div>
+            <div class="card-body">
+                <div class="row">
+                    <div class="col-md-6">
+                        <h6>Qu'est-ce qu'une saison ?</h6>
+                        <p class="text-muted">Une saison est une période de compétition avec un classement distinct. Chaque saison a ses propres statistiques et classements.</p>
+                    </div>
+                    <div class="col-md-6">
+                        <h6>Commencer une nouvelle saison</h6>
+                        <p class="text-muted">Démarrer une nouvelle saison termine la saison actuelle, sauvegarde les résultats finaux et remet tous les ELO à 1000.</p>
+                    </div>
+                </div>
+                <div class="alert alert-warning mt-3">
+                    <i class="bi bi-exclamation-triangle"></i>
+                    <strong>Attention :</strong> Démarrer une nouvelle saison est irréversible et remet à zéro tous les ELO des joueurs.
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/views/admin_start_season.php
+++ b/src/views/admin_start_season.php
@@ -1,0 +1,120 @@
+<div class="row">
+    <div class="col-md-8 mx-auto">
+        <div class="card">
+            <div class="card-header bg-warning text-dark">
+                <h4 class="mb-0">
+                    <i class="bi bi-exclamation-triangle"></i> Commencer une Nouvelle Saison
+                </h4>
+            </div>
+            <div class="card-body">
+                <div class="alert alert-warning">
+                    <i class="bi bi-info-circle"></i>
+                    <strong>Attention :</strong> Cette action va :
+                    <ul class="mb-0 mt-2">
+                        <li>Terminer la saison actuelle et sauvegarder les résultats finaux</li>
+                        <li>Remettre tous les ELO des joueurs à 1000</li>
+                        <li>Créer une nouvelle saison</li>
+                    </ul>
+                    <p class="mt-2 mb-0"><strong>Cette action est irréversible !</strong></p>
+                </div>
+
+                <?php if ($current_season): ?>
+                <div class="card mb-4">
+                    <div class="card-header">
+                        <h6><i class="bi bi-calendar-event"></i> Saison Actuelle</h6>
+                    </div>
+                    <div class="card-body">
+                        <h5><?php echo htmlspecialchars($current_season['name']); ?></h5>
+                        <p class="text-muted">
+                            Commencée le <?php echo date('d/m/Y à H:i', strtotime($current_season['start_date'])); ?>
+                        </p>
+                    </div>
+                </div>
+                <?php endif; ?>
+
+                <?php if (isset($error)): ?>
+                <div class="alert alert-danger">
+                    <i class="bi bi-exclamation-circle"></i> <?php echo $error; ?>
+                </div>
+                <?php endif; ?>
+
+                <form method="POST">
+                    <div class="mb-3">
+                        <label for="season_name" class="form-label">
+                            <i class="bi bi-tag"></i> Nom de la nouvelle saison *
+                        </label>
+                        <input type="text" 
+                               class="form-control" 
+                               id="season_name" 
+                               name="season_name" 
+                               placeholder="ex: Saison Été 2025, Championnat Automne..."
+                               required
+                               maxlength="100">
+                        <div class="form-text">
+                            Choisissez un nom descriptif pour cette saison (maximum 100 caractères)
+                        </div>
+                    </div>
+
+                    <div class="row">
+                        <div class="col-6">
+                            <a href="index.php?page=admin&action=seasons" class="btn btn-secondary w-100">
+                                <i class="bi bi-arrow-left"></i> Annuler
+                            </a>
+                        </div>
+                        <div class="col-6">
+                            <button type="submit" class="btn btn-warning w-100" onclick="return confirmNewSeason()">
+                                <i class="bi bi-plus-circle"></i> Commencer la Saison
+                            </button>
+                        </div>
+                    </div>
+                </form>
+            </div>
+        </div>
+
+        <!-- Preview of what will happen -->
+        <div class="card mt-4">
+            <div class="card-header">
+                <h6><i class="bi bi-list-check"></i> Que va-t-il se passer ?</h6>
+            </div>
+            <div class="card-body">
+                <div class="row">
+                    <div class="col-md-6">
+                        <h6 class="text-danger">Saison actuelle</h6>
+                        <ul class="list-unstyled">
+                            <li><i class="bi bi-check-circle text-success"></i> Les résultats finaux seront sauvegardés</li>
+                            <li><i class="bi bi-check-circle text-success"></i> Le classement final sera archivé</li>
+                            <li><i class="bi bi-check-circle text-success"></i> La saison sera marquée comme terminée</li>
+                        </ul>
+                    </div>
+                    <div class="col-md-6">
+                        <h6 class="text-success">Nouvelle saison</h6>
+                        <ul class="list-unstyled">
+                            <li><i class="bi bi-arrow-clockwise text-primary"></i> Tous les ELO remis à 1000</li>
+                            <li><i class="bi bi-calendar-plus text-primary"></i> Nouvelle saison créée</li>
+                            <li><i class="bi bi-trophy text-primary"></i> Nouveau classement vierge</li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<script>
+function confirmNewSeason() {
+    const seasonName = document.getElementById('season_name').value.trim();
+    if (!seasonName) {
+        alert('Veuillez entrer un nom pour la nouvelle saison.');
+        return false;
+    }
+    
+    return confirm(
+        `Êtes-vous sûr de vouloir commencer la nouvelle saison "${seasonName}" ?\n\n` +
+        `Cette action va :\n` +
+        `- Terminer la saison actuelle\n` +
+        `- Remettre tous les ELO à 1000\n` +
+        `- Créer la nouvelle saison\n\n` +
+        `Cette action est IRRÉVERSIBLE !`
+    );
+}
+</script>

--- a/src/views/game_details.php
+++ b/src/views/game_details.php
@@ -7,17 +7,9 @@
                 Partie du <?php echo date('d/m/Y à H:i', strtotime($game_data['date_partie'])); ?>
             </h5>
             <div>
-                <?php if (isset($game_data['is_ranked'])): ?>
-                    <?php if ($game_data['is_ranked']): ?>
-                        <span class="badge bg-success">
-                            <i class="bi bi-trophy"></i> Classée
-                        </span>
-                    <?php else: ?>
-                        <span class="badge bg-info">
-                            <i class="bi bi-heart"></i> Amicale
-                        </span>
-                    <?php endif; ?>
-                <?php endif; ?>
+                <span class="badge bg-success">
+                    <i class="bi bi-trophy"></i> Classée
+                </span>
                 <?php if (isset($game_data['season_name']) && $game_data['season_name']): ?>
                     <span class="badge bg-secondary">
                         <i class="bi bi-calendar-event"></i> <?php echo htmlspecialchars($game_data['season_name']); ?>

--- a/src/views/game_details.php
+++ b/src/views/game_details.php
@@ -1,10 +1,30 @@
 <?php if ($game_data): ?>
 <div class="card">
     <div class="card-header">
-        <h5>
-            <i class="bi bi-calendar3"></i> 
-            Partie du <?php echo date('d/m/Y à H:i', strtotime($game_data['date_partie'])); ?>
-        </h5>
+        <div class="d-flex justify-content-between align-items-center">
+            <h5>
+                <i class="bi bi-calendar3"></i> 
+                Partie du <?php echo date('d/m/Y à H:i', strtotime($game_data['date_partie'])); ?>
+            </h5>
+            <div>
+                <?php if (isset($game_data['is_ranked'])): ?>
+                    <?php if ($game_data['is_ranked']): ?>
+                        <span class="badge bg-success">
+                            <i class="bi bi-trophy"></i> Classée
+                        </span>
+                    <?php else: ?>
+                        <span class="badge bg-info">
+                            <i class="bi bi-heart"></i> Amicale
+                        </span>
+                    <?php endif; ?>
+                <?php endif; ?>
+                <?php if (isset($game_data['season_name']) && $game_data['season_name']): ?>
+                    <span class="badge bg-secondary">
+                        <i class="bi bi-calendar-event"></i> <?php echo htmlspecialchars($game_data['season_name']); ?>
+                    </span>
+                <?php endif; ?>
+            </div>
+        </div>
     </div>
     <div class="card-body">
         <!-- Gagnant -->

--- a/src/views/game_finish.php
+++ b/src/views/game_finish.php
@@ -11,6 +11,17 @@
                 <div class="text-center mb-4">
                     <h4>🏆 Félicitations <?php echo htmlspecialchars($game_data['gagnant_pseudo']); ?> !</h4>
                     <p class="lead">Partie terminée le <?php echo date('d/m/Y à H:i', strtotime($game_data['date_partie'])); ?></p>
+                    <?php if (isset($game_data['is_ranked'])): ?>
+                        <?php if ($game_data['is_ranked']): ?>
+                            <div class="alert alert-success">
+                                <i class="bi bi-trophy"></i> <strong>Partie classée</strong> - Les ELO ont été mis à jour
+                            </div>
+                        <?php else: ?>
+                            <div class="alert alert-info">
+                                <i class="bi bi-heart"></i> <strong>Partie amicale</strong> - Les ELO n'ont pas été affectés
+                            </div>
+                        <?php endif; ?>
+                    <?php endif; ?>
                 </div>
 
                 <!-- Classement final -->
@@ -89,32 +100,40 @@
                                 </td>
                                 <td>
                                     <?php
-                                    // Récupérer le changement d'ELO pour ce joueur
-                                    $elo_data = isset($elo_changes[$player['user_id']]) ? $elo_changes[$player['user_id']] : null;
-                                    $old_elo = $elo_data ? $elo_data['old_elo'] : $user_data['elo'];
-                                    $new_elo = $elo_data ? $elo_data['new_elo'] : $user_data['elo'];
-                                    $change = $elo_data ? $elo_data['elo_change'] : 0;
-                                    
-                                    // Définir la couleur et l'icône en fonction du changement d'ELO
-                                    $badge_class = "bg-info";
-                                    $icon_class = "bi-dash";
-                                    $text_class = "text-secondary";
-                                    
-                                    if ($change > 0) {
-                                        $badge_class = "bg-success";
-                                        $icon_class = "bi-arrow-up";
-                                        $text_class = "text-success";
-                                    } elseif ($change < 0) {
-                                        $badge_class = "bg-danger";
-                                        $icon_class = "bi-arrow-down";
-                                        $text_class = "text-danger";
+                                    // Check if this is a ranked game first
+                                    if (isset($game_data['is_ranked']) && !$game_data['is_ranked']) {
+                                        // Unranked game - no ELO change
+                                        echo '<span class="text-muted"><i class="bi bi-dash"></i> Non classée</span>';
+                                    } else {
+                                        // Ranked game - show ELO change
+                                        $elo_data = isset($elo_changes[$player['user_id']]) ? $elo_changes[$player['user_id']] : null;
+                                        $old_elo = $elo_data ? $elo_data['old_elo'] : $user_data['elo'];
+                                        $new_elo = $elo_data ? $elo_data['new_elo'] : $user_data['elo'];
+                                        $change = $elo_data ? $elo_data['elo_change'] : 0;
+                                        
+                                        // Définir la couleur et l'icône en fonction du changement d'ELO
+                                        $badge_class = "bg-info";
+                                        $icon_class = "bi-dash";
+                                        $text_class = "text-secondary";
+                                        
+                                        if ($change > 0) {
+                                            $badge_class = "bg-success";
+                                            $icon_class = "bi-arrow-up";
+                                            $text_class = "text-success";
+                                        } elseif ($change < 0) {
+                                            $badge_class = "bg-danger";
+                                            $icon_class = "bi-arrow-down";
+                                            $text_class = "text-danger";
+                                        }
+                                        ?>
+                                        <span class="badge <?php echo $badge_class; ?>"><?php echo $new_elo; ?> ELO</span>
+                                        <i class="bi <?php echo $icon_class; ?> <?php echo $text_class; ?>"></i>
+                                        <small class="<?php echo $text_class; ?>">
+                                            <?php echo $change > 0 ? '+' . $change : $change; ?>
+                                        </small>
+                                        <?php
                                     }
                                     ?>
-                                    <span class="badge <?php echo $badge_class; ?>"><?php echo $new_elo; ?> ELO</span>
-                                    <i class="bi <?php echo $icon_class; ?> <?php echo $text_class; ?>"></i>
-                                    <small class="<?php echo $text_class; ?>">
-                                        <?php echo $change > 0 ? '+' . $change : $change; ?>
-                                    </small>
                                 </td>
                             </tr>
                             <?php 

--- a/src/views/game_finish.php
+++ b/src/views/game_finish.php
@@ -11,17 +11,9 @@
                 <div class="text-center mb-4">
                     <h4>🏆 Félicitations <?php echo htmlspecialchars($game_data['gagnant_pseudo']); ?> !</h4>
                     <p class="lead">Partie terminée le <?php echo date('d/m/Y à H:i', strtotime($game_data['date_partie'])); ?></p>
-                    <?php if (isset($game_data['is_ranked'])): ?>
-                        <?php if ($game_data['is_ranked']): ?>
-                            <div class="alert alert-success">
-                                <i class="bi bi-trophy"></i> <strong>Partie classée</strong> - Les ELO ont été mis à jour
-                            </div>
-                        <?php else: ?>
-                            <div class="alert alert-info">
-                                <i class="bi bi-heart"></i> <strong>Partie amicale</strong> - Les ELO n'ont pas été affectés
-                            </div>
-                        <?php endif; ?>
-                    <?php endif; ?>
+                    <div class="alert alert-success">
+                        <i class="bi bi-trophy"></i> <strong>Partie classée</strong> - Les ELO ont été mis à jour
+                    </div>
                 </div>
 
                 <!-- Classement final -->
@@ -100,40 +92,32 @@
                                 </td>
                                 <td>
                                     <?php
-                                    // Check if this is a ranked game first
-                                    if (isset($game_data['is_ranked']) && !$game_data['is_ranked']) {
-                                        // Unranked game - no ELO change
-                                        echo '<span class="text-muted"><i class="bi bi-dash"></i> Non classée</span>';
-                                    } else {
-                                        // Ranked game - show ELO change
-                                        $elo_data = isset($elo_changes[$player['user_id']]) ? $elo_changes[$player['user_id']] : null;
-                                        $old_elo = $elo_data ? $elo_data['old_elo'] : $user_data['elo'];
-                                        $new_elo = $elo_data ? $elo_data['new_elo'] : $user_data['elo'];
-                                        $change = $elo_data ? $elo_data['elo_change'] : 0;
-                                        
-                                        // Définir la couleur et l'icône en fonction du changement d'ELO
-                                        $badge_class = "bg-info";
-                                        $icon_class = "bi-dash";
-                                        $text_class = "text-secondary";
-                                        
-                                        if ($change > 0) {
-                                            $badge_class = "bg-success";
-                                            $icon_class = "bi-arrow-up";
-                                            $text_class = "text-success";
-                                        } elseif ($change < 0) {
-                                            $badge_class = "bg-danger";
-                                            $icon_class = "bi-arrow-down";
-                                            $text_class = "text-danger";
-                                        }
+                                    // All games are ranked - show ELO change
+                                    $elo_data = isset($elo_changes[$player['user_id']]) ? $elo_changes[$player['user_id']] : null;
+                                    $old_elo = $elo_data ? $elo_data['old_elo'] : $user_data['elo'];
+                                    $new_elo = $elo_data ? $elo_data['new_elo'] : $user_data['elo'];
+                                    $change = $elo_data ? $elo_data['elo_change'] : 0;
+                                    
+                                    // Définir la couleur et l'icône en fonction du changement d'ELO
+                                    $badge_class = "bg-info";
+                                    $icon_class = "bi-dash";
+                                    $text_class = "text-secondary";
+                                    
+                                    if ($change > 0) {
+                                        $badge_class = "bg-success";
+                                        $icon_class = "bi-arrow-up";
+                                        $text_class = "text-success";
+                                    } elseif ($change < 0) {
+                                        $badge_class = "bg-danger";
+                                        $icon_class = "bi-arrow-down";
+                                        $text_class = "text-danger";
+                                    }
                                         ?>
                                         <span class="badge <?php echo $badge_class; ?>"><?php echo $new_elo; ?> ELO</span>
                                         <i class="bi <?php echo $icon_class; ?> <?php echo $text_class; ?>"></i>
                                         <small class="<?php echo $text_class; ?>">
                                             <?php echo $change > 0 ? '+' . $change : $change; ?>
                                         </small>
-                                        <?php
-                                    }
-                                    ?>
                                 </td>
                             </tr>
                             <?php 

--- a/src/views/game_play.php
+++ b/src/views/game_play.php
@@ -2,7 +2,22 @@
     <div class="col-md-8 mx-auto">
         <div class="card">
             <div class="card-header bg-primary text-white">
-                <h4><i class="bi bi-controller"></i> Partie en cours - Manche <?php echo $current_round; ?>/10</h4>
+                <div class="d-flex justify-content-between align-items-center">
+                    <h4><i class="bi bi-controller"></i> Partie en cours - Manche <?php echo $current_round; ?>/10</h4>
+                    <div>
+                        <?php if (isset($game_data['is_ranked'])): ?>
+                            <?php if ($game_data['is_ranked']): ?>
+                                <span class="badge bg-warning">
+                                    <i class="bi bi-trophy"></i> Classée
+                                </span>
+                            <?php else: ?>
+                                <span class="badge bg-light text-dark">
+                                    <i class="bi bi-heart"></i> Amicale
+                                </span>
+                            <?php endif; ?>
+                        <?php endif; ?>
+                    </div>
+                </div>
             </div>
             <div class="card-body">
                 <?php if (isset($_GET['error'])): ?>

--- a/src/views/game_play.php
+++ b/src/views/game_play.php
@@ -5,17 +5,9 @@
                 <div class="d-flex justify-content-between align-items-center">
                     <h4><i class="bi bi-controller"></i> Partie en cours - Manche <?php echo $current_round; ?>/10</h4>
                     <div>
-                        <?php if (isset($game_data['is_ranked'])): ?>
-                            <?php if ($game_data['is_ranked']): ?>
-                                <span class="badge bg-warning">
-                                    <i class="bi bi-trophy"></i> Classée
-                                </span>
-                            <?php else: ?>
-                                <span class="badge bg-light text-dark">
-                                    <i class="bi bi-heart"></i> Amicale
-                                </span>
-                            <?php endif; ?>
-                        <?php endif; ?>
+                        <span class="badge bg-warning">
+                            <i class="bi bi-trophy"></i> Classée
+                        </span>
                     </div>
                 </div>
             </div>

--- a/src/views/history.php
+++ b/src/views/history.php
@@ -1,11 +1,19 @@
 <?php
 require_once '../config/database.php';
 require_once '../src/models/Game.php';
+require_once '../src/models/Season.php';
 
 $database = new Database();
 $db = $database->getConnection();
 $game = new Game($db);
-$games = $game->getAll(50);
+$season = new Season($db);
+
+// Get current season and all seasons
+$current_season = $season->getCurrentSeason();
+$all_seasons = $season->getAllSeasons();
+
+// Get current season games (ranked only)
+$current_season_games = $current_season ? $season->getSeasonGames($current_season['id'], true, 20) : null;
 ?>
 
 <div class="row">
@@ -13,12 +21,40 @@ $games = $game->getAll(50);
         <h2><i class="bi bi-clock-history text-info"></i> Historique des Parties</h2>
         <p class="lead">Retrouvez toutes les parties terminées</p>
 
-        <?php if ($games->rowCount() > 0): ?>
-        <div class="card">
+<div class="row">
+    <div class="col-md-12">
+        <h2><i class="bi bi-clock-history text-info"></i> Historique des Saisons</h2>
+        <p class="lead">Retrouvez les parties et classements de chaque saison</p>
+
+        <!-- Current Season -->
+        <?php if ($current_season): ?>
+        <div class="card mb-4 border-success">
+            <div class="card-header bg-success text-white">
+                <h4 class="mb-0">
+                    <i class="bi bi-star-fill"></i> 
+                    <?php echo htmlspecialchars($current_season['name']); ?> (Saison Actuelle)
+                </h4>
+            </div>
             <div class="card-body">
+                <div class="row">
+                    <div class="col-md-8">
+                        <p class="mb-1">
+                            <i class="bi bi-calendar3"></i> 
+                            Commencée le <?php echo date('d/m/Y à H:i', strtotime($current_season['start_date'])); ?>
+                        </p>
+                        <p class="text-muted mb-3">Parties classées uniquement</p>
+                    </div>
+                    <div class="col-md-4 text-end">
+                        <a href="index.php?page=ranking&season=<?php echo $current_season['id']; ?>" class="btn btn-outline-light">
+                            <i class="bi bi-trophy"></i> Voir le classement
+                        </a>
+                    </div>
+                </div>
+                
+                <?php if ($current_season_games && $current_season_games->rowCount() > 0): ?>
                 <div class="table-responsive">
-                    <table class="table table-striped table-hover">
-                        <thead class="table-dark">
+                    <table class="table table-sm table-hover">
+                        <thead>
                             <tr>
                                 <th>Date</th>
                                 <th>Gagnant</th>
@@ -27,22 +63,22 @@ $games = $game->getAll(50);
                             </tr>
                         </thead>
                         <tbody>
-                            <?php while ($row = $games->fetch(PDO::FETCH_ASSOC)): ?>
+                            <?php while ($game_row = $current_season_games->fetch(PDO::FETCH_ASSOC)): ?>
                             <tr>
                                 <td>
                                     <i class="bi bi-calendar3"></i>
-                                    <?php echo date('d/m/Y H:i', strtotime($row['date_partie'])); ?>
+                                    <?php echo date('d/m/Y H:i', strtotime($game_row['date_partie'])); ?>
                                 </td>
                                 <td>
                                     <i class="bi bi-trophy-fill text-warning"></i>
-                                    <strong><?php echo htmlspecialchars($row['gagnant_pseudo']); ?></strong>
+                                    <strong><?php echo htmlspecialchars($game_row['gagnant_pseudo']); ?></strong>
                                 </td>
                                 <td>
-                                    <span class="badge bg-primary"><?php echo $row['nombre_joueurs']; ?> joueurs</span>
+                                    <span class="badge bg-primary"><?php echo $game_row['nombre_joueurs']; ?> joueurs</span>
                                 </td>
                                 <td>
                                     <button class="btn btn-sm btn-outline-info" 
-                                            onclick="showGameDetails(<?php echo $row['id']; ?>)" 
+                                            onclick="showGameDetails(<?php echo $game_row['id']; ?>)" 
                                             data-bs-toggle="modal" 
                                             data-bs-target="#gameDetailsModal">
                                         <i class="bi bi-eye"></i> Détails
@@ -53,15 +89,178 @@ $games = $game->getAll(50);
                         </tbody>
                     </table>
                 </div>
+                <?php else: ?>
+                <div class="alert alert-info">
+                    <i class="bi bi-info-circle"></i>
+                    Aucune partie classée jouée dans cette saison pour le moment.
+                </div>
+                <?php endif; ?>
             </div>
         </div>
-        <?php else: ?>
-        <div class="alert alert-info text-center">
-            <i class="bi bi-info-circle-fill"></i>
-            Aucune partie terminée pour le moment. 
-            <a href="index.php" class="alert-link">Lancez votre première partie !</a>
-        </div>
         <?php endif; ?>
+
+        <!-- Past Seasons -->
+        <div class="card">
+            <div class="card-header">
+                <h5><i class="bi bi-archive"></i> Saisons Précédentes</h5>
+            </div>
+            <div class="card-body">
+                <?php if ($all_seasons): ?>
+                    <div class="accordion" id="pastSeasonsAccordion">
+                        <?php 
+                        $accordion_count = 0;
+                        while ($season_row = $all_seasons->fetch(PDO::FETCH_ASSOC)): 
+                            if ($season_row['is_current']) continue; // Skip current season
+                            $accordion_count++;
+                            
+                            // Get season stats and games
+                            $season_stats = $season->getSeasonStats($season_row['id']);
+                            $season_games = $season->getSeasonGames($season_row['id'], true, 10);
+                            $season_summary = $season->getSeasonSummary($season_row['id']);
+                        ?>
+                        <div class="accordion-item">
+                            <h2 class="accordion-header" id="heading<?php echo $accordion_count; ?>">
+                                <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" 
+                                        data-bs-target="#collapse<?php echo $accordion_count; ?>" 
+                                        aria-expanded="false" aria-controls="collapse<?php echo $accordion_count; ?>">
+                                    <div class="w-100">
+                                        <div class="d-flex justify-content-between align-items-center">
+                                            <div>
+                                                <strong><?php echo htmlspecialchars($season_row['name']); ?></strong>
+                                                <small class="text-muted ms-2">
+                                                    <?php echo date('d/m/Y', strtotime($season_row['start_date'])); ?>
+                                                    - 
+                                                    <?php echo $season_row['end_date'] ? date('d/m/Y', strtotime($season_row['end_date'])) : 'En cours'; ?>
+                                                </small>
+                                            </div>
+                                            <div class="text-muted">
+                                                <?php if ($season_summary): ?>
+                                                    <small><?php echo $season_summary['total_games']; ?> parties • <?php echo $season_summary['total_players']; ?> joueurs</small>
+                                                <?php endif; ?>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </button>
+                            </h2>
+                            <div id="collapse<?php echo $accordion_count; ?>" class="accordion-collapse collapse" 
+                                 aria-labelledby="heading<?php echo $accordion_count; ?>" data-bs-parent="#pastSeasonsAccordion">
+                                <div class="accordion-body">
+                                    <div class="row">
+                                        <!-- Final Rankings -->
+                                        <div class="col-md-6">
+                                            <h6><i class="bi bi-trophy"></i> Classement Final</h6>
+                                            <?php if ($season_stats && $season_stats->rowCount() > 0): ?>
+                                            <div class="table-responsive">
+                                                <table class="table table-sm">
+                                                    <thead>
+                                                        <tr>
+                                                            <th>Rang</th>
+                                                            <th>Joueur</th>
+                                                            <th>ELO</th>
+                                                            <th>Parties</th>
+                                                            <th>Victoires</th>
+                                                        </tr>
+                                                    </thead>
+                                                    <tbody>
+                                                        <?php 
+                                                        $count = 0;
+                                                        while ($stat = $season_stats->fetch(PDO::FETCH_ASSOC)): 
+                                                            if ($count >= 5) break; // Show only top 5
+                                                        ?>
+                                                        <tr>
+                                                            <td>
+                                                                <?php if ($stat['final_rank'] == 1): ?>
+                                                                    <i class="bi bi-trophy-fill text-warning"></i>
+                                                                <?php elseif ($stat['final_rank'] == 2): ?>
+                                                                    <i class="bi bi-award-fill text-secondary"></i>
+                                                                <?php elseif ($stat['final_rank'] == 3): ?>
+                                                                    <i class="bi bi-award-fill text-warning"></i>
+                                                                <?php else: ?>
+                                                                    <?php echo $stat['final_rank']; ?>
+                                                                <?php endif; ?>
+                                                            </td>
+                                                            <td><strong><?php echo htmlspecialchars($stat['pseudo']); ?></strong></td>
+                                                            <td><span class="badge bg-info"><?php echo $stat['final_elo']; ?></span></td>
+                                                            <td><?php echo $stat['parties_jouees']; ?></td>
+                                                            <td><?php echo $stat['victoires']; ?></td>
+                                                        </tr>
+                                                        <?php 
+                                                        $count++;
+                                                        endwhile; ?>
+                                                    </tbody>
+                                                </table>
+                                            </div>
+                                            <?php else: ?>
+                                            <div class="alert alert-info">
+                                                <small>Aucune statistique disponible</small>
+                                            </div>
+                                            <?php endif; ?>
+                                        </div>
+                                        
+                                        <!-- Recent Games -->
+                                        <div class="col-md-6">
+                                            <h6><i class="bi bi-clock-history"></i> Dernières Parties</h6>
+                                            <?php if ($season_games && $season_games->rowCount() > 0): ?>
+                                            <div class="table-responsive">
+                                                <table class="table table-sm">
+                                                    <thead>
+                                                        <tr>
+                                                            <th>Date</th>
+                                                            <th>Gagnant</th>
+                                                            <th>Joueurs</th>
+                                                        </tr>
+                                                    </thead>
+                                                    <tbody>
+                                                        <?php while ($game_row = $season_games->fetch(PDO::FETCH_ASSOC)): ?>
+                                                        <tr>
+                                                            <td class="small">
+                                                                <?php echo date('d/m H:i', strtotime($game_row['date_partie'])); ?>
+                                                            </td>
+                                                            <td>
+                                                                <strong><?php echo htmlspecialchars($game_row['gagnant_pseudo']); ?></strong>
+                                                            </td>
+                                                            <td>
+                                                                <span class="badge bg-primary"><?php echo $game_row['nombre_joueurs']; ?></span>
+                                                            </td>
+                                                        </tr>
+                                                        <?php endwhile; ?>
+                                                    </tbody>
+                                                </table>
+                                            </div>
+                                            <?php else: ?>
+                                            <div class="alert alert-info">
+                                                <small>Aucune partie trouvée</small>
+                                            </div>
+                                            <?php endif; ?>
+                                        </div>
+                                    </div>
+                                    
+                                    <!-- View Full Season Button -->
+                                    <div class="text-center mt-3">
+                                        <a href="index.php?page=ranking&season=<?php echo $season_row['id']; ?>" class="btn btn-outline-primary btn-sm">
+                                            <i class="bi bi-eye"></i> Voir la saison complète
+                                        </a>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <?php endwhile; ?>
+                        
+                        <?php if ($accordion_count == 0): ?>
+                        <div class="alert alert-info">
+                            <i class="bi bi-info-circle"></i>
+                            Aucune saison précédente trouvée.
+                        </div>
+                        <?php endif; ?>
+                    </div>
+                <?php else: ?>
+                <div class="alert alert-info">
+                    <i class="bi bi-info-circle"></i>
+                    Aucune saison trouvée.
+                </div>
+                <?php endif; ?>
+            </div>
+        </div>
     </div>
 </div>
 

--- a/src/views/home.php
+++ b/src/views/home.php
@@ -168,25 +168,6 @@ $users = $user->getAll();
                         <i class="bi bi-exclamation-triangle-fill"></i>
                         Veuillez sélectionner entre 1 et 6 joueurs.
                     </div>
-                    
-                    <!-- Game Type Selection -->
-                    <div class="mt-4">
-                        <h6><i class="bi bi-gear-fill"></i> Type de partie</h6>
-                        <div class="form-check">
-                            <input class="form-check-input" type="radio" name="is_ranked" id="ranked" value="1" checked>
-                            <label class="form-check-label" for="ranked">
-                                <strong>Partie classée</strong>
-                                <small class="text-muted d-block">Affecte les ELO et les statistiques saisonnières</small>
-                            </label>
-                        </div>
-                        <div class="form-check">
-                            <input class="form-check-input" type="radio" name="is_ranked" id="unranked" value="0">
-                            <label class="form-check-label" for="unranked">
-                                <strong>Partie amicale</strong>
-                                <small class="text-muted d-block">N'affecte pas les ELO, juste pour s'amuser</small>
-                            </label>
-                        </div>
-                    </div>
                 </div>
                 <div class="modal-footer">
                     <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Annuler</button>

--- a/src/views/home.php
+++ b/src/views/home.php
@@ -168,6 +168,25 @@ $users = $user->getAll();
                         <i class="bi bi-exclamation-triangle-fill"></i>
                         Veuillez sélectionner entre 1 et 6 joueurs.
                     </div>
+                    
+                    <!-- Game Type Selection -->
+                    <div class="mt-4">
+                        <h6><i class="bi bi-gear-fill"></i> Type de partie</h6>
+                        <div class="form-check">
+                            <input class="form-check-input" type="radio" name="is_ranked" id="ranked" value="1" checked>
+                            <label class="form-check-label" for="ranked">
+                                <strong>Partie classée</strong>
+                                <small class="text-muted d-block">Affecte les ELO et les statistiques saisonnières</small>
+                            </label>
+                        </div>
+                        <div class="form-check">
+                            <input class="form-check-input" type="radio" name="is_ranked" id="unranked" value="0">
+                            <label class="form-check-label" for="unranked">
+                                <strong>Partie amicale</strong>
+                                <small class="text-muted d-block">N'affecte pas les ELO, juste pour s'amuser</small>
+                            </label>
+                        </div>
+                    </div>
                 </div>
                 <div class="modal-footer">
                     <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Annuler</button>

--- a/src/views/ranking.php
+++ b/src/views/ranking.php
@@ -13,8 +13,14 @@ $current_season = $season->getCurrentSeason();
 $season_id = isset($_GET['season']) ? $_GET['season'] : ($current_season ? $current_season['id'] : null);
 
 // Get users for the specified season (or all-time if no season)
-$users = $season_id ? $season->getCurrentSeasonRankings() : $user->getAll();
+$users = $season_id ? $season->getSeasonRankings($season_id) : $user->getAll();
 $all_seasons = $season->getAllSeasons();
+
+// Get selected season info for display
+$selected_season = null;
+if ($season_id) {
+    $selected_season = $season->getById($season_id);
+}
 ?>
 
 <div class="row">
@@ -24,7 +30,7 @@ $all_seasons = $season->getAllSeasons();
             <div class="dropdown">
                 <button class="btn btn-outline-secondary dropdown-toggle" type="button" data-bs-toggle="dropdown">
                     <i class="bi bi-calendar-event"></i> 
-                    <?php echo $season_id && $current_season ? htmlspecialchars($current_season['name']) : 'Tout temps'; ?>
+                    <?php echo $selected_season ? htmlspecialchars($selected_season['name']) : 'Tout temps'; ?>
                 </button>
                 <ul class="dropdown-menu">
                     <li><a class="dropdown-item" href="index.php?page=ranking">Tout temps</a></li>
@@ -45,10 +51,16 @@ $all_seasons = $season->getAllSeasons();
             </div>
         </div>
         
-        <?php if ($season_id && $current_season): ?>
+        <?php if ($selected_season): ?>
         <p class="lead">
-            Classement de la saison actuelle : <strong><?php echo htmlspecialchars($current_season['name']); ?></strong>
-            <small class="text-muted">(parties classées uniquement)</small>
+            Classement de la saison : <strong><?php echo htmlspecialchars($selected_season['name']); ?></strong>
+            <?php if ($selected_season['is_current']): ?>
+                <span class="badge bg-success ms-1">Actuelle</span>
+                <small class="text-muted">(parties classées uniquement)</small>
+            <?php else: ?>
+                <span class="badge bg-secondary ms-1">Terminée</span>
+                <small class="text-muted">(classement final)</small>
+            <?php endif; ?>
         </p>
         <?php else: ?>
         <p class="lead">Classement général des joueurs par ordre de rating ELO</p>

--- a/src/views/ranking.php
+++ b/src/views/ranking.php
@@ -1,17 +1,58 @@
 <?php
 require_once '../config/database.php';
 require_once '../src/models/User.php';
+require_once '../src/models/Season.php';
 
 $database = new Database();
 $db = $database->getConnection();
 $user = new User($db);
-$users = $user->getAll();
+$season = new Season($db);
+
+// Get current season
+$current_season = $season->getCurrentSeason();
+$season_id = isset($_GET['season']) ? $_GET['season'] : ($current_season ? $current_season['id'] : null);
+
+// Get users for the specified season (or all-time if no season)
+$users = $season_id ? $season->getCurrentSeasonRankings() : $user->getAll();
+$all_seasons = $season->getAllSeasons();
 ?>
 
 <div class="row">
     <div class="col-md-10 mx-auto">
-        <h2><i class="bi bi-trophy-fill text-warning"></i> Classement ELO</h2>
-        <p class="lead">Classement des joueurs par ordre de rating ELO</p>
+        <div class="d-flex justify-content-between align-items-center mb-3">
+            <h2><i class="bi bi-trophy-fill text-warning"></i> Classement ELO</h2>
+            <div class="dropdown">
+                <button class="btn btn-outline-secondary dropdown-toggle" type="button" data-bs-toggle="dropdown">
+                    <i class="bi bi-calendar-event"></i> 
+                    <?php echo $season_id && $current_season ? htmlspecialchars($current_season['name']) : 'Tout temps'; ?>
+                </button>
+                <ul class="dropdown-menu">
+                    <li><a class="dropdown-item" href="index.php?page=ranking">Tout temps</a></li>
+                    <?php if ($all_seasons): ?>
+                        <?php while ($season_row = $all_seasons->fetch(PDO::FETCH_ASSOC)): ?>
+                        <li>
+                            <a class="dropdown-item <?php echo $season_id == $season_row['id'] ? 'active' : ''; ?>" 
+                               href="index.php?page=ranking&season=<?php echo $season_row['id']; ?>">
+                                <?php echo htmlspecialchars($season_row['name']); ?>
+                                <?php if ($season_row['is_current']): ?>
+                                    <span class="badge bg-success ms-1">Actuelle</span>
+                                <?php endif; ?>
+                            </a>
+                        </li>
+                        <?php endwhile; ?>
+                    <?php endif; ?>
+                </ul>
+            </div>
+        </div>
+        
+        <?php if ($season_id && $current_season): ?>
+        <p class="lead">
+            Classement de la saison actuelle : <strong><?php echo htmlspecialchars($current_season['name']); ?></strong>
+            <small class="text-muted">(parties classées uniquement)</small>
+        </p>
+        <?php else: ?>
+        <p class="lead">Classement général des joueurs par ordre de rating ELO</p>
+        <?php endif; ?>
 
         <div class="card">
             <div class="card-body">
@@ -31,63 +72,73 @@ $users = $user->getAll();
                         <tbody>
                             <?php 
                             $rank = 1;
-                            while ($row = $users->fetch(PDO::FETCH_ASSOC)): 
-                                $win_rate = $row['parties_jouees'] > 0 ? round(($row['victoires'] / $row['parties_jouees']) * 100) : 0;
-                                
-                                // Déterminer le badge selon l'ELO
-                                $badge = '';
-                                $badge_class = '';
-                                if ($row['elo'] >= 1400) {
-                                    $badge = 'Maître';
-                                    $badge_class = 'bg-danger';
-                                } elseif ($row['elo'] >= 1200) {
-                                    $badge = 'Expert';
-                                    $badge_class = 'bg-warning';
-                                } elseif ($row['elo'] >= 1000) {
-                                    $badge = 'Intermédiaire';
-                                    $badge_class = 'bg-primary';
-                                } else {
-                                    $badge = 'Débutant';
-                                    $badge_class = 'bg-secondary';
-                                }
-                            ?>
-                            <tr>
-                                <td>
-                                    <?php if ($rank == 1): ?>
-                                        <i class="bi bi-trophy-fill text-warning"></i>
-                                    <?php elseif ($rank == 2): ?>
-                                        <i class="bi bi-award-fill text-secondary"></i>
-                                    <?php elseif ($rank == 3): ?>
-                                        <i class="bi bi-award-fill text-warning"></i>
-                                    <?php else: ?>
-                                        <span class="fw-bold"><?php echo $rank; ?></span>
-                                    <?php endif; ?>
-                                </td>
-                                <td>
-                                    <strong><?php echo htmlspecialchars($row['pseudo']); ?></strong>
-                                    <?php if ($rank <= 3): ?>
-                                        <i class="bi bi-star-fill text-warning"></i>
-                                    <?php endif; ?>
-                                </td>
-                                <td>
-                                    <span class="badge bg-info fs-6"><?php echo $row['elo']; ?></span>
-                                </td>
-                                <td><?php echo $row['parties_jouees']; ?></td>
-                                <td><?php echo $row['victoires']; ?></td>
-                                <td>
-                                    <div class="progress" style="height: 20px;">
-                                        <div class="progress-bar" role="progressbar" style="width: <?php echo $win_rate; ?>%">
-                                            <?php echo $win_rate; ?>%
+                            if ($users && (is_object($users) ? $users->rowCount() > 0 : count($users) > 0)): 
+                                $users_array = is_object($users) ? $users->fetchAll(PDO::FETCH_ASSOC) : $users;
+                                foreach ($users_array as $row): 
+                                    $win_rate = $row['parties_jouees'] > 0 ? round(($row['victoires'] / $row['parties_jouees']) * 100) : 0;
+                                    
+                                    // Déterminer le badge selon l'ELO
+                                    $badge = '';
+                                    $badge_class = '';
+                                    if ($row['elo'] >= 1400) {
+                                        $badge = 'Maître';
+                                        $badge_class = 'bg-danger';
+                                    } elseif ($row['elo'] >= 1200) {
+                                        $badge = 'Expert';
+                                        $badge_class = 'bg-warning';
+                                    } elseif ($row['elo'] >= 1000) {
+                                        $badge = 'Intermédiaire';
+                                        $badge_class = 'bg-primary';
+                                    } else {
+                                        $badge = 'Débutant';
+                                        $badge_class = 'bg-secondary';
+                                    }
+                                ?>
+                                <tr>
+                                    <td>
+                                        <?php if ($rank == 1): ?>
+                                            <i class="bi bi-trophy-fill text-warning"></i>
+                                        <?php elseif ($rank == 2): ?>
+                                            <i class="bi bi-award-fill text-secondary"></i>
+                                        <?php elseif ($rank == 3): ?>
+                                            <i class="bi bi-award-fill text-warning"></i>
+                                        <?php else: ?>
+                                            <span class="fw-bold"><?php echo $rank; ?></span>
+                                        <?php endif; ?>
+                                    </td>
+                                    <td>
+                                        <strong><?php echo htmlspecialchars($row['pseudo']); ?></strong>
+                                        <?php if ($rank <= 3): ?>
+                                            <i class="bi bi-star-fill text-warning"></i>
+                                        <?php endif; ?>
+                                    </td>
+                                    <td>
+                                        <span class="badge bg-info fs-6"><?php echo $row['elo']; ?></span>
+                                    </td>
+                                    <td><?php echo $row['parties_jouees']; ?></td>
+                                    <td><?php echo $row['victoires']; ?></td>
+                                    <td>
+                                        <div class="progress" style="height: 20px;">
+                                            <div class="progress-bar" role="progressbar" style="width: <?php echo $win_rate; ?>%">
+                                                <?php echo $win_rate; ?>%
+                                            </div>
                                         </div>
-                                    </div>
-                                </td>
-                                <td>
-                                    <span class="badge <?php echo $badge_class; ?>"><?php echo $badge; ?></span>
-                                </td>
-                            </tr>
-                            <?php 
-                            $rank++;
-                            endwhile; ?>
+                                    </td>
+                                    <td>
+                                        <span class="badge <?php echo $badge_class; ?>"><?php echo $badge; ?></span>
+                                    </td>
+                                </tr>
+                                <?php 
+                                $rank++;
+                                endforeach;
+                            else: ?>
+                                <tr>
+                                    <td colspan="7" class="text-center text-muted">
+                                        <i class="bi bi-info-circle"></i>
+                                        <?php echo $season_id ? 'Aucune partie jouée dans cette saison.' : 'Aucun joueur trouvé.'; ?>
+                                    </td>
+                                </tr>
+                            <?php endif; ?>
                         </tbody>
                     </table>
                 </div>


### PR DESCRIPTION
**verifier si ca marche avec le ranked game**

This PR introduces a season system for ranked matches:

✅ Added an admin-only option to start a new season

🔄 Starting a new season resets all players' Elo to 1000

🕓 Each season is dated with a start and end timestamp

📊 Created a global season history view, visible to all users

Shows current season standings

Allows expanding past seasons to view their results